### PR TITLE
Support for OS X

### DIFF
--- a/demo/glfw/Makefile
+++ b/demo/glfw/Makefile
@@ -15,7 +15,12 @@ ifeq ($(OS),Windows_NT)
 BIN := $(BIN).exe
 LIBS = -lglfw3 -lopengl32 -lm -lGLU32 -lGLEW32
 else
-LIBS = -lglfw -lGL -lm -lGLU -lGLEW
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Darwin)
+		LIBS = -lglfw3 -framework OpenGL -lm -lGLEW
+	else
+    LIBS = -lglfw -lGL -lm -lGLU -lGLEW
+	endif
 endif
 
 # Modes

--- a/demo/glfw/main.c
+++ b/demo/glfw/main.c
@@ -9,8 +9,13 @@
 #include <math.h>
 
 #include <GL/glew.h>
-#include <GL/gl.h>
-#include <GL/glu.h>
+#ifdef __APPLE__
+    #include <OpenGL/gl.h>
+    #include <OpenGL/glu.h>
+#else
+    #include <GL/gl.h>
+    #include <GL/glu.h>
+#endif
 #include <GLFW/glfw3.h>
 
 /* these defines are both needed for the header

--- a/demo/glfw/nuklear_glfw.c
+++ b/demo/glfw/nuklear_glfw.c
@@ -30,12 +30,18 @@ static struct nk_glfw {
     float scroll;
 } glfw;
 
+#ifdef __APPLE__
+  #define NK_SHADER_VERSION "#version 400\n"
+#else
+  #define NK_SHADER_VERSION "#version 300 es\n"
+#endif
+
 NK_API void
 nk_glfw3_device_create(void)
 {
     GLint status;
     static const GLchar *vertex_shader =
-        "#version 300 es\n"
+        NK_SHADER_VERSION
         "uniform mat4 ProjMtx;\n"
         "in vec2 Position;\n"
         "in vec2 TexCoord;\n"
@@ -48,7 +54,7 @@ nk_glfw3_device_create(void)
         "   gl_Position = ProjMtx * vec4(Position.xy, 0, 1);\n"
         "}\n";
     static const GLchar *fragment_shader =
-        "#version 300 es\n"
+        NK_SHADER_VERSION
         "precision mediump float;\n"
         "uniform sampler2D Texture;\n"
         "in vec2 Frag_UV;\n"


### PR DESCRIPTION
This is a proposal for OS X support. 

Currently, I've only implemented this for the GLFW example, but I can update this PR to support the other demos and examples as well.

Here's what it does:
- Update the Makefile to check for OS X and use `-framework OpenGL`.
- Use conditional includes in `main.c`.
- In `nuklear_glfw.c`, define a `NK_SHADER_VERSION` which is set to `#version 400` on OS X and `#version 300 es` otherwise. Version 300 es doesn't work on OS X.

With regards to conditional includes, it seems that GLFW will include the default [OpenGL headers by itself](http://www.glfw.org/docs/latest/build.html#build_include) (this works on OS X at least, haven't tested on Linux / Windows). If this works everywhere we could just remove the conditional include in `main.c`.
