### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Github language settings
+*.h linguist-language=c
+*.c linguist-language=c


### PR DESCRIPTION
This file makes sure github doesn't confuse .c and .h files in this repository for C++ files. This should list the repository under the right programming language.