### PR TITLE
Use standard C compiler by default

### DIFF
--- a/demo/allegro5/Makefile
+++ b/demo/allegro5/Makefile
@@ -1,10 +1,6 @@
 # Install
 BIN = demo
 
-# Compiler
-CC = clang
-DCC = gcc
-
 # Flags
 CFLAGS = -std=c89 -pedantic
 
@@ -22,15 +18,6 @@ else
 		LIBS = -lallegro -lallegro_primitives -lallegro_main -lGL -lm -lGLU -lGLEW
 	endif
 endif
-
-# Modes
-.PHONY: gcc
-gcc: CC = gcc
-gcc: $(BIN)
-
-.PHONY: clang
-clang: CC = clang
-clang: $(BIN)
 
 $(BIN):
 	@mkdir -p bin

--- a/demo/glfw/Makefile
+++ b/demo/glfw/Makefile
@@ -1,10 +1,6 @@
 # Install
 BIN = demo
 
-# Compiler
-CC = clang
-DCC = gcc
-
 # Flags
 CFLAGS = -std=c99 -pedantic -O2
 
@@ -22,15 +18,6 @@ else
     LIBS = -lglfw -lGL -lm -lGLU -lGLEW
 	endif
 endif
-
-# Modes
-.PHONY: clang
-clang: CC = clang
-clang: $(BIN)
-
-.PHONY: gcc
-gcc: CC = gcc
-gcc: $(BIN)
 
 $(BIN):
 	@mkdir -p bin

--- a/demo/sdl/Makefile
+++ b/demo/sdl/Makefile
@@ -1,10 +1,6 @@
 # Install
 BIN = demo
 
-# Compiler
-CC = clang
-DCC = gcc
-
 # Flags
 CFLAGS = -std=c99 -pedantic -O2
 
@@ -22,15 +18,6 @@ else
 		LIBS = -lSDL2 -lGL -lm -lGLU -lGLEW
 	endif
 endif
-
-# Modes
-.PHONY: clang
-clang: CC = clang
-clang: $(BIN)
-
-.PHONY: gcc
-gcc: CC = gcc
-gcc: $(BIN)
 
 $(BIN):
 	@mkdir -p bin

--- a/demo/x11/Makefile
+++ b/demo/x11/Makefile
@@ -1,24 +1,11 @@
 # Install
 BIN = zahnrad
 
-# Compiler
-CC = clang
-DCC = gcc
-
 # Flags
 CFLAGS = -std=c89 -pedantic -O2
 
 SRC = main.c
 OBJ = $(SRC:.c=.o)
-
-# Modes
-.PHONY: gcc
-gcc: CC = gcc
-gcc: $(BIN)
-
-.PHONY: clang
-clang: CC = clang
-clang: $(BIN)
 
 $(BIN):
 	@mkdir -p bin

--- a/example/Makefile
+++ b/example/Makefile
@@ -1,6 +1,3 @@
-# Compiler
-CC = clang
-
 # Flags
 CFLAGS = -std=c99 -pedantic -O2
 


### PR DESCRIPTION
Always use the standard compiler as defined by the environment
variable CC. User can set it when a different compiler if required
(e.g. CC=clang make)