### PR TITLE
Fix compilation error

### DIFF
--- a/demo/sdl/main.c
+++ b/demo/sdl/main.c
@@ -31,7 +31,7 @@
 #define MAX_ELEMENT_MEMORY 128 * 1024
 
 int
-main(void)
+main(int argc, char* argv[])
 {
     /* Platform */
     SDL_Window *win;


### PR DESCRIPTION
```
rm -f bin/demo.exe 
clang main.c -std=c99 -pedantic -O2 -o bin/demo.exe -lmingw32 -lSDL2main -lSDL2 -lopengl32 -lm -lGLU32 -lGLEW32
main.c:34:1: error: conflicting types for 'SDL_main'
main(void)
^
c:\msys64\mingw64\include\SDL2/SDL_main.h:104:17: note: expanded from macro 'main'
#define main    SDL_main
                ^
c:\msys64\mingw64\include\SDL2/SDL_main.h:110:22: note: previous declaration is here
extern C_LINKAGE int SDL_main(int argc, char *argv[]);
                     ^
1 error generated.
Makefile:36: recipe for target 'demo.exe' failed
mingw32-make: *** [demo.exe] Error 1
```

`int main(void)` should be `int main(int argc, char *argv[])`