### PR TITLE
Add -framework flags to glfw Makefile to build on Darwin

### DIFF
--- a/demo/glfw/Makefile
+++ b/demo/glfw/Makefile
@@ -2,7 +2,7 @@
 BIN = demo
 
 # Flags
-CFLAGS = -std=c99 -pedantic -O2
+CFLAGS = -std=c99 -pedantic -O2 -I/usr/local/include
 
 SRC = main.c
 OBJ = $(SRC:.c=.o)
@@ -13,7 +13,7 @@ LIBS = -lglfw3 -lopengl32 -lm -lGLU32 -lGLEW32
 else
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S),Darwin)
-		LIBS = -lglfw3 -framework OpenGL -lm -lGLEW
+		LIBS = -L/usr/local/lib/ -lglfw3 -framework OpenGL -framework CoreFoundation -framework CoreGraphics -framework CoreVideo -framework IOKit -framework AppKit -framework Carbon -lm -lGLEW
 	else
     LIBS = -lglfw -lGL -lm -lGLU -lGLEW
 	endif


### PR DESCRIPTION
I needed to add several `-framework` flags to get the glfw demo to build on Darwin. I even needed to add `-I/usr/local/include` and `-L/usr/local/lib`, which was odd. Maybe this will be useful to you?