### PR TITLE
Added an error message if the display can't be opened

### DIFF
--- a/demo/x11/main.c
+++ b/demo/x11/main.c
@@ -87,6 +87,8 @@ main(void)
     /* X11 */
     memset(&xw, 0, sizeof xw);
     xw.dpy = XOpenDisplay(NULL);
+    if (!xw.dpy) die("Could not open a display; perhaps $DISPLAY is not set?");
+
     xw.root = DefaultRootWindow(xw.dpy);
     xw.screen = XDefaultScreen(xw.dpy);
     xw.vis = XDefaultVisual(xw.dpy, xw.screen);


### PR DESCRIPTION
The x11 example currently segfaults if it can't open a display. Detect the failure and print an error message.