### PR TITLE
Allow updating window bounds.

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -14884,6 +14884,7 @@ nk_begin(struct nk_context *ctx, struct nk_panel *layout, const char *title,
         /* update public window flags */
         win->flags &= ~(nk_flags)(NK_WINDOW_PRIVATE-1);
         win->flags |= flags;
+        win->bounds = bounds;
         win->seq++;
         if (!ctx->active)
             ctx->active = win;


### PR DESCRIPTION
Allow window bounds to be updated with `nk_begin`.