### PR TITLE
Example: add OS X specific include and library paths to Makefile

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -7,7 +7,8 @@ LIBS = -lglfw3 -lopengl32 -lm -lGLU32 -lGLEW32
 else
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S),Darwin)
-		LIBS = -lglfw3 -framework OpenGL -lm -lGLEW
+		LIBS = -lglfw3 -framework OpenGL -lm -lGLEW -L/usr/local/lib
+		CFLAGS += -I/usr/local/include
 	else
 		LIBS = -lglfw -lGL -lm -lGLU -lGLEW
 	endif


### PR DESCRIPTION
This change makes it easy to build from scratch for a beginner (of course, they still need to install `glew` from homebrew).