### PR TITLE
Allow static windows position update.

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -15006,6 +15006,8 @@ nk_begin(struct nk_context *ctx, struct nk_panel *layout, const char *title,
         win->flags &= ~(nk_flags)(NK_WINDOW_PRIVATE-1);
         win->flags |= flags;
         win->seq++;
+        if (!(win->flags & NK_WINDOW_MOVABLE))
+			win->bounds = bounds;
         if (!ctx->active)
             ctx->active = win;
     }


### PR DESCRIPTION
Currently any position change is ignored.
Its a problem if you want to create a gui and rescale the draw area during runtine.
This patch will allow windows with not NK_WINDOW_MOVEABLE set to update the position.
