### PR TITLE
fixed 'unsigned short' overflow when drawing widget text with font size > widget height

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -9838,7 +9838,9 @@ nk_font_atlas_end(struct nk_font_atlas *atlas, nk_handle texture,
     }
     for (i = 0; i < atlas->font_num; ++i) {
         atlas->fonts[i]->texture = texture;
+#ifdef NK_INCLUDE_VERTEX_BUFFER_OUTPUT
         atlas->fonts[i]->handle.texture = texture;
+#endif
     }
 
     atlas->alloc.free(atlas->alloc.userdata, atlas->pixel);

--- a/nuklear.h
+++ b/nuklear.h
@@ -11259,7 +11259,7 @@ nk_widget_text(struct nk_command_buffer *o, struct nk_rect b,
     /* align in y-axis */
     if (a & NK_TEXT_ALIGN_MIDDLE) {
         label.y = b.y + b.h/2.0f - (float)f->height/2.0f;
-        label.h = b.h - (b.h/2.0f + f->height/2.0f);
+        label.h = NK_MAX(b.h/2.0f, b.h - (b.h/2.0f + f->height/2.0f));
     } else if (a & NK_TEXT_ALIGN_BOTTOM) {
         label.y = b.y + b.h - f->height;
         label.h = f->height;


### PR DESCRIPTION
When `f->height` is greater than `b.h` then resulting `label.h` will become negative and inside call of `nk_draw_text` in expression `cmd->h = (unsigned short)r.h;` resulting h will become **USHRT_MAX**.