### PR TITLE
don't depend on the title in nk_tree_push_hashed if a hash is already…

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -15226,7 +15226,7 @@ nk_window_is_any_hovered(struct nk_context *ctx)
             return 1;
         }
         /* check if window popup is being hovered */
-        if (iter->popup.active && nk_input_is_mouse_hovering_rect(&ctx->input, iter->popup.win->bounds))
+        if (iter->popup.active && iter->popup.win && nk_input_is_mouse_hovering_rect(&ctx->input, iter->popup.win->bounds))
             return 1;
         iter = iter->next;
     }

--- a/nuklear.h
+++ b/nuklear.h
@@ -16621,7 +16621,7 @@ nk_tree_base(struct nk_context *ctx, enum nk_tree_type type,
 
     nk_flags ws = 0;
     int title_len = 0;
-    nk_hash title_hash = 0;
+    nk_hash tree_hash = 0;
     nk_uint *state = 0;
     enum nk_widget_layout_states widget_state;
 
@@ -16657,12 +16657,15 @@ nk_tree_base(struct nk_context *ctx, enum nk_tree_type type,
     } else text.background = style->window.background;
 
     /* find, create or set tab persistent state (open/closed) */
-    title_len = (int)nk_strlen(title);
-    title_hash = nk_murmur_hash(title, (int)title_len, (nk_hash)type);
-    if (hash) title_hash += nk_murmur_hash(hash, len, (nk_hash)line);
-    state = nk_find_value(win, title_hash);
+    if (hash) {
+        tree_hash = nk_murmur_hash(hash, len, (nk_hash)line);
+    } else {
+        title_len = (int)nk_strlen(title);
+        tree_hash = nk_murmur_hash(title, (int)title_len, (nk_hash)line);
+    }
+    state = nk_find_value(win, tree_hash);
     if (!state) {
-        state = nk_add_value(ctx, win, title_hash, 0);
+        state = nk_add_value(ctx, win, tree_hash, 0);
         *state = initial_state;
     }
 


### PR DESCRIPTION
… specified to allow editing the title text from inside the node/tab.

I'm not sure whether this could break things in other places/situations.
Note that I removed the type of the tree entry from the hash to include the line/id in both cases instead.