### PR TITLE
horizontal scrollbar fixes

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -15633,10 +15633,16 @@ nk_panel_begin(struct nk_context *ctx, const char *title)
     }
 
     /* calculate window footer height */
-    if (!(win->flags & NK_WINDOW_NONBLOCK) &&
-        (!(win->flags & NK_WINDOW_NO_SCROLLBAR) || (win->flags & NK_WINDOW_SCALABLE)))
-        layout->footer_h = scaler_size.y + style->window.footer_padding.y;
-    else layout->footer_h = 0;
+    layout->footer_h = 0;
+
+    if (!(win->flags & NK_WINDOW_NONBLOCK)) {
+      if (!(win->flags & NK_WINDOW_NO_SCROLLBAR)) {
+        layout->footer_h = scrollbar_size.y + style->window.footer_padding.y;
+      }
+      if (win->flags & NK_WINDOW_SCALABLE) {
+        layout->footer_h = NK_MAX(layout->footer_h, scaler_size.y + style->window.footer_padding.y);
+      }
+    }
 
     /* calculate the window size */
     if (!(win->flags & NK_WINDOW_NO_SCROLLBAR))
@@ -15968,19 +15974,19 @@ nk_panel_end(struct nk_context *ctx)
             nk_flags state = 0;
             bounds.x = layout->bounds.x + window_padding.x;
             if (layout->flags & NK_WINDOW_SUB) {
-                bounds.h = scrollbar_size.x;
+                bounds.h = scrollbar_size.y;
                 bounds.y = (layout->flags & NK_WINDOW_BORDER) ?
                             layout->bounds.y + layout->border : layout->bounds.y;
                 bounds.y += layout->header_h + layout->menu.h + layout->height;
                 bounds.w = layout->width;
             } else if (layout->flags & NK_WINDOW_DYNAMIC) {
-                bounds.h = NK_MIN(scrollbar_size.x, layout->footer_h);
+                bounds.h = NK_MIN(scrollbar_size.y, layout->footer_h);
                 bounds.w = layout->bounds.w;
                 bounds.y = footer.y;
             } else {
-                bounds.h = NK_MIN(scrollbar_size.x, layout->footer_h);
+                bounds.h = NK_MIN(scrollbar_size.y, layout->footer_h);
                 bounds.y = layout->bounds.y + window->bounds.h;
-                bounds.y -= NK_MAX(layout->footer_h, scrollbar_size.x);
+                bounds.y -= NK_MAX(layout->footer_h, scrollbar_size.y);
                 bounds.w = layout->width - 2 * window_padding.x;
             }
             scroll_offset = layout->offset->x;


### PR DESCRIPTION
While working on a texture preview window containing a horizontally scrolling window of images, I hit a few edge cases with horizontal scrollbars.

First, my window didn't container a scaler so they panel's height was calculated incorrectly. The old calculation used scaler_size (16) when either scrollbars or scalers were enabled, as opposed to the max of either scaler_size (16) or scrollbar_size.y (10). Since my window was aligned to the bottom of the screen there was a 6 pixel gap between container and the bottom of the screen due to this.

Second, the horizontal scrollbars used the scrollbar_size.x to determine their final position, as opposed to scollbar_size.y. Being that my window didn't have any vertical scrolling I had set scrollbar_size.x to 0, which then causes the horizontal scrollbar to be position incorrectly.

I've attached a before and after of the use case.

Before (scrollbar is completely not visible):
![screenshot from 2016-06-23 22-44-34](https://cloud.githubusercontent.com/assets/460296/16329362/c58637c4-3996-11e6-945d-51560401a7c3.png)

After (bright green is the scrollbar background):
![screenshot from 2016-06-23 22-43-09](https://cloud.githubusercontent.com/assets/460296/16329368/cf97593c-3996-11e6-91dc-0642b45be767.png)
