### PR TITLE
Fixes misuse of spaces in GLFW demo Makefiles

### DIFF
--- a/demo/glfw_opengl2/Makefile
+++ b/demo/glfw_opengl2/Makefile
@@ -15,7 +15,7 @@ else
 	ifeq ($(UNAME_S),Darwin)
 		LIBS = -lglfw3 -framework OpenGL -lm
 	else
-    LIBS = -lglfw -lGL -lm -lGLU
+		LIBS = -lglfw -lGL -lm -lGLU
 	endif
 endif
 

--- a/demo/glfw_opengl3/Makefile
+++ b/demo/glfw_opengl3/Makefile
@@ -15,7 +15,7 @@ else
 	ifeq ($(UNAME_S),Darwin)
 		LIBS = -lglfw3 -framework OpenGL -lm -lGLEW
 	else
-    LIBS = -lglfw -lGL -lm -lGLU -lGLEW
+		LIBS = -lglfw -lGL -lm -lGLU -lGLEW
 	endif
 endif
 


### PR DESCRIPTION
The same line is indented using 4 spaces instead of 1 tab in both files.