### PR TITLE
Fix incorrect printf token in nk_value_format_byte

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -17196,7 +17196,7 @@ nk_value_float(struct nk_context *ctx, const char *prefix, float value)
 
 NK_API void
 nk_value_color_byte(struct nk_context *ctx, const char *p, struct nk_color c)
-{nk_labelf(ctx, NK_TEXT_LEFT, "%s: (%c, %c, %c, %c)", p, c.r, c.g, c.b, c.a);}
+{nk_labelf(ctx, NK_TEXT_LEFT, "%s: (%u, %u, %u, %u)", p, c.r, c.g, c.b, c.a);}
 
 NK_API void
 nk_value_color_float(struct nk_context *ctx, const char *p, struct nk_color color)


### PR DESCRIPTION
Makes this:

![nuklear_byte_printf_fail](https://cloud.githubusercontent.com/assets/712560/16710151/dcb6df36-462d-11e6-828e-9b5a97c752d6.png)

look like this:

![nuklear_byte_printf_expect](https://cloud.githubusercontent.com/assets/712560/16710155/f43809dc-462d-11e6-877e-8c1810d26321.png)
