### PR TITLE
Fix nk_input_key to enable keyboard key repeat

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -10000,7 +10000,6 @@ nk_input_key(struct nk_context *ctx, enum nk_keys key, int down)
     NK_ASSERT(ctx);
     if (!ctx) return;
     in = &ctx->input;
-    if (in->keyboard.keys[key].down == down) return;
     in->keyboard.keys[key].down = down;
     in->keyboard.keys[key].clicked++;
 }


### PR DESCRIPTION
It seems to me that the following change doesn't break anything, but I am not 100% sure. Can you confirm if I am missing something?

`clicked` value gets cleared in `nk_input_begin` for every key anyway, so `clicked` value getting larger shouldn't matter (unless of course the user calls the `nk_input_begin` so many times that the `clicked` value overflows :smile:.

Anyway having keyboard key repeat work for backspace & arrows makes me very happy. Key repeat works fine on `nk_input_glyph`.