### PR TITLE
Change popup toggling semantics

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -18639,13 +18639,13 @@ nk_nonblock_begin(struct nk_panel *layout, struct nk_context *ctx,
         win->popup.win = popup;
         nk_command_buffer_init(&popup->buffer, &ctx->memory, NK_CLIPPING_ON);
     } else {
-        /* check if user clicked outside the popup and close if so */
-        int clicked, in_body, in_header;
-        clicked = nk_input_has_mouse_click(&ctx->input, NK_BUTTON_LEFT);
-        in_body = nk_input_is_mouse_click_in_rect(&ctx->input, NK_BUTTON_LEFT, body);
-        in_header = nk_input_is_mouse_click_in_rect(&ctx->input, NK_BUTTON_LEFT, header);
+        /* close the popup if user pressed outside or in the header */
+        int pressed, in_body, in_header;
+        pressed = nk_input_is_mouse_pressed(&ctx->input, NK_BUTTON_LEFT);
+        in_body = nk_input_is_mouse_hovering_rect(&ctx->input, body);
+        in_header = nk_input_is_mouse_hovering_rect(&ctx->input, header);
 
-        if (clicked && !in_body && !in_header)
+        if (pressed && (!in_body || in_header))
             is_active = nk_false;
     }
 


### PR DESCRIPTION
For gui elements like tree tabs, tree nodes and windows themselves,
you can repeatedly click the same "minimize" region and it keeps
toggling that element. This was not the case with "popup" type of
elements. This commit slightly changes how the popups close once
they are already open.

Like before, the user can close the popup by just clicking outside
the popups region. Now the user can also close the popup by clicking
the "header" region of the popup.

Here is how the change looks like:

![PopupToggling](https://cloud.githubusercontent.com/assets/712560/16712225/282ef72c-4689-11e6-9c71-d0c35aa5d388.gif)

