### PR TITLE
Enhancement: 'nk_buffer_push' function now returns address

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -10000,7 +10000,6 @@ nk_input_key(struct nk_context *ctx, enum nk_keys key, int down)
     NK_ASSERT(ctx);
     if (!ctx) return;
     in = &ctx->input;
-    if (in->keyboard.keys[key].down == down) return;
     in->keyboard.keys[key].down = down;
     in->keyboard.keys[key].clicked++;
 }

--- a/nuklear.h
+++ b/nuklear.h
@@ -981,7 +981,8 @@ NK_API void nk_buffer_init_default(struct nk_buffer*);
 NK_API void nk_buffer_init(struct nk_buffer*, const struct nk_allocator*, nk_size size);
 NK_API void nk_buffer_init_fixed(struct nk_buffer*, void *memory, nk_size size);
 NK_API void nk_buffer_info(struct nk_memory_status*, struct nk_buffer*);
-NK_API void nk_buffer_push(struct nk_buffer*, enum nk_buffer_allocation_type type, void *memory, nk_size size, nk_size align);
+NK_API void *nk_buffer_push(struct nk_buffer*, enum nk_buffer_allocation_type type,
+    const void *memory, nk_size size, nk_size align);
 NK_API void nk_buffer_mark(struct nk_buffer*, enum nk_buffer_allocation_type type);
 NK_API void nk_buffer_reset(struct nk_buffer*, enum nk_buffer_allocation_type type);
 NK_API void nk_buffer_clear(struct nk_buffer*);
@@ -4398,13 +4399,14 @@ nk_buffer_alloc(struct nk_buffer *b, enum nk_buffer_allocation_type type,
     return memory;
 }
 
-NK_API void
+NK_API void*
 nk_buffer_push(struct nk_buffer *b, enum nk_buffer_allocation_type type,
-    void *memory, nk_size size, nk_size align)
+    const void *memory, nk_size size, nk_size align)
 {
     void *mem = nk_buffer_alloc(b, type, size, align);
-    if (!mem) return;
+    if (!mem) return 0;
     NK_MEMCPY(mem, memory, size);
+    return mem;
 }
 
 NK_API void

--- a/nuklear.h
+++ b/nuklear.h
@@ -2269,7 +2269,7 @@ struct nk_panel {
     float footer_h;
     float header_h;
     float border;
-	unsigned int has_scrolling;
+    unsigned int has_scrolling;
     struct nk_rect clip;
     struct nk_menu_state menu;
     struct nk_row_layout row;
@@ -2536,7 +2536,9 @@ template<typename T> struct nk_alignof{struct Big {T x; char c;}; enum {
 #define NK_COS nk_cos
 #endif
 
-/* make sure correct type size */
+/* make sure correct type size:
+ * This will fire with a negative subscript error if the type sizes
+ * are set incorrectly by the compiler, and compile out if not */
 typedef int nk__check_size[(sizeof(nk_size) >= sizeof(void*)) ? 1 : -1];
 typedef int nk__check_ptr[(sizeof(nk_ptr) == sizeof(void*)) ? 1 : -1];
 typedef int nk__check_flags[(sizeof(nk_flags) >= 4) ? 1 : -1];
@@ -6435,7 +6437,6 @@ nk_draw_list_add_text(struct nk_draw_list *list, const struct nk_user_font *font
 
         /* calculate and draw glyph drawing rectangle and image */
         gx = x + g.offset.x;
-        /*gy = rect.y + (rect.h/2) - (font->height/2) + g.offset.y;*/
         gy = rect.y + g.offset.y;
         gw = g.width; gh = g.height;
         char_width = g.xadvance;
@@ -6468,7 +6469,7 @@ nk_convert(struct nk_context *ctx, struct nk_buffer *cmds,
     nk_foreach(cmd, ctx)
     {
 #ifdef NK_INCLUDE_COMMAND_USERDATA
-        list->userdata = cmd->userdata;
+        ctx->draw_list.userdata = cmd->userdata;
 #endif
         switch (cmd->type) {
         case NK_COMMAND_NOP: break;


### PR DESCRIPTION
Previously, **nk_buffer_push** function returned void. With this commit it returns address of item
which was added to buffer. One can use this address to get a pointer to that item inside the buffer (for example to modify its fields or pass this pointer to another code).