### PR TITLE
Fixed multiple crashes in font handling

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -8917,7 +8917,7 @@ nk_font_bake_pack(struct nk_font_baker *baker,
     /* setup font baker from temporary memory */
     for (config_iter = config_list; config_iter; config_iter = config_iter->next) {
         const struct nk_font_config *cfg = config_iter;
-        if (!nk_tt_InitFont(&baker->build[i].info, (const unsigned char*)cfg->ttf_blob, 0))
+        if (!nk_tt_InitFont(&baker->build[i++].info, (const unsigned char*)cfg->ttf_blob, 0))
             return nk_false;
     }
 
@@ -9263,7 +9263,6 @@ nk_font_init(struct nk_font *font, float pixel_height,
         return;
 
     baked = *baked_font;
-    nk_zero(font, sizeof(*font));
     font->info = baked;
     font->scale = (float)pixel_height / (float)font->info.height;
     font->glyphs = &glyphs[baked_font->glyph_offset];

--- a/nuklear.h
+++ b/nuklear.h
@@ -1224,7 +1224,7 @@ NK_API void nk_textedit_redo(struct nk_text_edit*);
     The final approach if you do not have a font handling functionality or don't
     want to use it in this library is by using the optional font baker. This API
     is divided into a high- and low-level API with different priorities between
-    ease of use and control. Both API's can be used to create a font and 
+    ease of use and control. Both API's can be used to create a font and
     font atlas texture and can even be used with or without the vertex buffer
     output. So it still uses the `nk_user_font` struct and the two different
     approaches previously stated still work.
@@ -2533,6 +2533,8 @@ struct nk_context {
     (type*)((void*)((char*)(1 ? (ptr): &((type*)0)->member) - NK_OFFSETOF(type, member)))
 
 #ifdef __cplusplus
+}
+
 template<typename T> struct nk_alignof;
 template<typename T, int size_diff> struct nk_helper{enum {value = size_diff};};
 template<typename T> struct nk_helper<T,0>{enum {value = nk_alignof<T>::value};};
@@ -2541,10 +2543,7 @@ template<typename T> struct nk_alignof{struct Big {T x; char c;}; enum {
 #define NK_ALIGNOF(t) (nk_alignof<t>::value);
 #else
 #define NK_ALIGNOF(t) ((char*)(&((struct {char c; t _h;}*)0)->_h) - (char*)0)
-#endif
 
-#ifdef __cplusplus
-}
 #endif
 #endif /* NK_H_ */
 
@@ -13339,7 +13338,7 @@ nk_do_edit(nk_flags *state, struct nk_command_buffer *out,
             const char *begin = nk_str_get_const(&edit->string);
             int l = nk_str_len_char(&edit->string);
             nk_edit_draw_text(out, style, area.x - edit->scrollbar.x,
-                area.y - edit->scrollbar.y, 0, begin, l, row_height, font, 
+                area.y - edit->scrollbar.y, 0, begin, l, row_height, font,
                 background_color, text_color, nk_false);
         } else {
             /* edit has selection so draw 1-3 text chunks */


### PR DESCRIPTION
Crashes happen when more than one font is present. First issue is only first font being initialized over and over and second one is `nk_zero` clearing `font->next` value which also prevents initialization of any fonts but first one.

As a bonus i snuck in compile error fix. c++ templates can not have external linkage. Whatever compiler is accepting that should be fixed ;)

P.S. i couldnt get font-awesome to work anyhow, displays question mark if i try to use

        nk_style_set_font(nk, &fa->handle);
        nk_button_label(nk, "\xEF\x80\x80");
        nk_button_label(nk, "\uF04B");

Any tips to get that working would be appreciated ;)

P.P.S. sorry for irrelevant space removals from line ends, blame IDE. If you wish i can clean commits up and get rid of them.
