### PR TITLE
Added window flag NK_WINDOW_SCALE_LEFT

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -575,7 +575,8 @@ enum nk_panel_flags {
     NK_WINDOW_NO_SCROLLBAR      = NK_FLAG(5), /* Removes the scrollbar from the window */
     NK_WINDOW_TITLE             = NK_FLAG(6), /* Forces a header at the top at the window showing the title */
     NK_WINDOW_SCROLL_AUTO_HIDE  = NK_FLAG(7), /* Automatically hides the window scrollbar if no user interaction */
-    NK_WINDOW_BACKGROUND        = NK_FLAG(8) /* Always keep window in the background */
+    NK_WINDOW_BACKGROUND        = NK_FLAG(8), /* Always keep window in the background */
+    NK_WINDOW_SCALE_LEFT        = NK_FLAG(9)  /* Puts window scaler on the left-bottom corner instead of right-bottom one and resizes window to the left */
 };
 
 /* context */
@@ -16865,17 +16866,30 @@ nk_panel_end(struct nk_context *ctx)
         scaler.w = scrollbar_size.x;
         scaler.h = scrollbar_size.y;
         scaler.y = layout->bounds.y + layout->bounds.h;
-        scaler.x = layout->bounds.x + layout->bounds.w + panel_padding.x;
+
+        if (layout->flags & NK_WINDOW_SCALE_LEFT) {
+            scaler.x = layout->bounds.x - panel_padding.x / 2;
+        } else {
+            scaler.x = layout->bounds.x + layout->bounds.w + panel_padding.x;
+        }
+        
         if (layout->flags & NK_WINDOW_NO_SCROLLBAR)
             scaler.x -= scaler.w;
 
         /* draw scaler */
         {const struct nk_style_item *item = &style->window.scaler;
-        if (item->type == NK_STYLE_ITEM_IMAGE)
+        if (item->type == NK_STYLE_ITEM_IMAGE) {
             nk_draw_image(out, scaler, &item->data.image, nk_white);
-        else nk_fill_triangle(out, scaler.x + scaler.w, scaler.y, scaler.x + scaler.w,
-            scaler.y + scaler.h, scaler.x, scaler.y + scaler.h, item->data.color);
-        }
+        } else {
+            if (layout->flags & NK_WINDOW_SCALE_LEFT) {
+                nk_fill_triangle(out, scaler.x, scaler.y, scaler.x,
+                    scaler.y + scaler.h, scaler.x + scaler.w,
+                    scaler.y + scaler.h, item->data.color);
+            } else {
+                nk_fill_triangle(out, scaler.x + scaler.w, scaler.y, scaler.x + scaler.w,
+                  scaler.y + scaler.h, scaler.x, scaler.y + scaler.h, item->data.color);
+            }
+        }}
 
         /* do window scaling */
         if (!(window->flags & NK_WINDOW_ROM)) {
@@ -16885,7 +16899,12 @@ nk_panel_end(struct nk_context *ctx)
                     NK_BUTTON_LEFT, scaler, nk_true);
 
             if (nk_input_is_mouse_down(in, NK_BUTTON_LEFT) && left_mouse_down && left_mouse_click_in_scaler) {
-                window->bounds.w = NK_MAX(window_size.x, window->bounds.w + in->mouse.delta.x);
+                float delta_x = in->mouse.delta.x;
+                if (layout->flags & NK_WINDOW_SCALE_LEFT) {
+                    delta_x = -delta_x;
+                    window->bounds.x += in->mouse.delta.x;
+                }
+                window->bounds.w = NK_MAX(window_size.x, window->bounds.w + delta_x);
                 /* dragging in y-direction is only possible if static window */
                 if (!(layout->flags & NK_WINDOW_DYNAMIC))
                     window->bounds.h = NK_MAX(window_size.y, window->bounds.h + in->mouse.delta.y);


### PR DESCRIPTION
 Added window flag `NK_WINDOW_SCALE_LEFT` which puts scaling handle to the left-bottom corner of the window and window scales to the left side instead of right one.

Motivation for this change is usecase when windows are used as panels attached to the right side of screen. Naturally expanding them is not possible because mouse goes out of screen after 10 pixels or so.
