### PR TITLE
Do not insert a backward delete

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -10861,6 +10861,10 @@ nk_textedit_text(struct nk_text_edit *state, const char *text, int total_len)
     if (!glyph_len) return;
     while ((text_len < total_len) && glyph_len)
     {
+        /* don't insert a backward delete, just process the event */
+        if (unicode == 127)
+            break;
+
         /* can't add newline in single-line mode */
         if (unicode == '\n' && state->single_line)
             break;


### PR DESCRIPTION
Not sure if this is something that is happening on several platforms, but my Mac keyboard sends unicode '127' as 'backspace' or the backward delete key.

Previously this event was being handled both as a valid text entry and as a text edit event. So the character was being inserted into the text edit string and then deleted, rendering the delete event non-functional.

Let me know if this needs to be handled elsewhere.