### PR TITLE
fix visual studio warning C4116

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -2691,6 +2691,8 @@ template<typename T> struct nk_helper<T,0>{enum {value = nk_alignof<T>::value};}
 template<typename T> struct nk_alignof{struct Big {T x; char c;}; enum {
     diff = sizeof(Big) - sizeof(T), value = nk_helper<Big, diff>::value};};
 #define NK_ALIGNOF(t) (nk_alignof<t>::value);
+#elif defined(_MSC_VER)
+#define NK_ALIGNOF(t) (__alignof(t))
 #else
 #define NK_ALIGNOF(t) ((char*)(&((struct {char c; t _h;}*)0)->_h) - (char*)0)
 #endif


### PR DESCRIPTION
This pull request fixes visual studio warning C4116.  Tested with Visual Studio 2015, though the `__alignof` operator goes back to at least vs2003, where MS no longer documents their compilers online.

I didn't see a place to put test coverage, but I tested it in x86 and x64 architectures with the following test code in a sample program.  In this program, `NK_ALIGNOF` is implemented with `__align` and `NK_ALIGNOF_ORIGINAL` is implemented with the warning-generating original definition.

No asserts are hit in either supported CPU architecture.


```
struct doublecontainer_s {
    double d;
};

    size_t ch1_align = NK_ALIGNOF(char);
    size_t ch2_align = NK_ALIGNOF_ORIGINAL(char);
    FTG_ASSERT(ch1_align == ch2_align);

    size_t int1_align = NK_ALIGNOF(int);
    size_t int2_align = NK_ALIGNOF_ORIGINAL(int);
    FTG_ASSERT(int1_align == int2_align);

    size_t ptr1_align = NK_ALIGNOF(int*);
    size_t ptr2_align = NK_ALIGNOF_ORIGINAL(int*);
    FTG_ASSERT(ptr1_align == ptr2_align);

    size_t doublec1_align = NK_ALIGNOF(struct doublecontainer_s);
    size_t doublec2_align = NK_ALIGNOF_ORIGINAL(struct doublecontainer_s);
    FTG_ASSERT(doublec1_align == doublec2_align);

    size_t double1_align = NK_ALIGNOF(double);
    size_t double2_align = NK_ALIGNOF_ORIGINAL(double);
    FTG_ASSERT(double1_align == double2_align);
```

