### PR TITLE
bugfix: nk_combo_separator showed incorrect item length and broken it…

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -21460,10 +21460,11 @@ nk_combo_separator(struct nk_context *ctx, const char *items_separated_by_separa
 
     /* find selected item */
     current_item = items_separated_by_separator;
-    for (i = 0; i < selected; ++i) {
+    for (i = 0; i < count; ++i) {
         iter = current_item;
-        while (*iter != separator) iter++;
+        while (*iter && *iter != separator) iter++;
         length = (int)(iter - current_item);
+        if (i == selected) break;
         current_item = iter + 1;
     }
 
@@ -21472,7 +21473,7 @@ nk_combo_separator(struct nk_context *ctx, const char *items_separated_by_separa
         nk_layout_row_dynamic(ctx, (float)item_height, 1);
         for (i = 0; i < count; ++i) {
             iter = current_item;
-            while (*iter != separator) iter++;
+            while (*iter && *iter != separator) iter++;
             length = (int)(iter - current_item);
             if (nk_combo_item_text(ctx, current_item, length, NK_TEXT_LEFT))
                 selected = i;


### PR DESCRIPTION
I think, there is a bug in nk_combo_separator.
I tried to fix it.
See below for details.
Thanks.

![test_program](https://cloud.githubusercontent.com/assets/18512546/19877483/fa5c45ea-a022-11e6-9b5c-de263d157a23.png)
![before_fixing](https://cloud.githubusercontent.com/assets/18512546/19877491/025d322c-a023-11e6-9225-dc7a6b490224.png)
![after_fixing](https://cloud.githubusercontent.com/assets/18512546/19877494/0562842c-a023-11e6-8967-de8cacf094c5.png)
