### PR TITLE
fix: nk_value_color_byte() shows incorrect text

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -18770,7 +18770,7 @@ nk_value_float(struct nk_context *ctx, const char *prefix, float value)
 
 NK_API void
 nk_value_color_byte(struct nk_context *ctx, const char *p, struct nk_color c)
-{nk_labelf(ctx, NK_TEXT_LEFT, "%s: (%c, %c, %c, %c)", p, c.r, c.g, c.b, c.a);}
+{nk_labelf(ctx, NK_TEXT_LEFT, "%s: (%d, %d, %d, %d)", p, c.r, c.g, c.b, c.a);}
 
 NK_API void
 nk_value_color_float(struct nk_context *ctx, const char *p, struct nk_color color)


### PR DESCRIPTION
I think, there is a bug in nk_value_color_byte.
I tried to fix it.
See below for details.
Thanks.
![fix__nk_value_color_byte__test_program](https://cloud.githubusercontent.com/assets/18512546/19956867/1ab09064-a1d4-11e6-8171-8aec36a3ce19.png)
![fix__nk_value_color_byte__before_fixing](https://cloud.githubusercontent.com/assets/18512546/19956872/25e16ca6-a1d4-11e6-8806-867fb110810e.png)
![fix__nk_value_color_byte__after_fixing](https://cloud.githubusercontent.com/assets/18512546/19956876/2bf1b920-a1d4-11e6-86dd-00ee23b5b4b0.png)
