### PR TITLE
fix: using nk_layout_row_begin() with NK_STATIC makes incorrect layout

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -18215,10 +18215,7 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
         item_width = layout->row.item_width;
         item_offset = layout->row.item_offset;
         item_spacing = (float)layout->row.index * spacing.x;
-        if (modify) {
-            layout->row.item_offset += item_width;
-            layout->row.index = 0;
-        }
+        if (modify) layout->row.item_offset += item_width;
     } break;
     case NK_LAYOUT_STATIC_FREE: {
         /* free widget placing */


### PR DESCRIPTION
Using nk_layout_row_begin() with NK_STATIC makes an incorrect layout.
I tried to fix it.

At least, this fixing makes correct result in this example.
But I'm not sure whether this fixing is always correct...

See below for details.
Thanks.
![1_test_program](https://cloud.githubusercontent.com/assets/18512546/20209490/13148f30-a838-11e6-9899-e1642a7b2a7d.png)
![2_before_fixing](https://cloud.githubusercontent.com/assets/18512546/20209495/1670f560-a838-11e6-9601-9ad8b4d81016.png)
![4_after_fixing](https://cloud.githubusercontent.com/assets/18512546/20209512/204076ce-a838-11e6-871e-44a712d6dea2.png)
