### PR TITLE
fix: key reaction timing in Windows demos

### DIFF
--- a/demo/d3d11/nuklear_d3d11.h
+++ b/demo/d3d11/nuklear_d3d11.h
@@ -205,7 +205,7 @@ nk_d3d11_handle_event(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
     case WM_SYSKEYDOWN:
     case WM_SYSKEYUP:
     {
-        int down = (lparam >> 31) & 1;
+        int down = (lparam >> 31) & 1 ? 0 : 1;
         int ctrl = GetKeyState(VK_CONTROL) & (1 << 15);
 
         switch (wparam)

--- a/demo/d3d11/nuklear_d3d11.h
+++ b/demo/d3d11/nuklear_d3d11.h
@@ -205,7 +205,7 @@ nk_d3d11_handle_event(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
     case WM_SYSKEYDOWN:
     case WM_SYSKEYUP:
     {
-        int down = (lparam >> 31) & 1 ? 0 : 1;
+        int down = !((lparam >> 31) & 1);
         int ctrl = GetKeyState(VK_CONTROL) & (1 << 15);
 
         switch (wparam)

--- a/demo/gdi/nuklear_gdi.h
+++ b/demo/gdi/nuklear_gdi.h
@@ -516,7 +516,7 @@ nk_gdi_handle_event(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
     case WM_SYSKEYDOWN:
     case WM_SYSKEYUP:
     {
-        int down = (lparam >> 31) & 1;
+        int down = (lparam >> 31) & 1 ? 0 : 1;
         int ctrl = GetKeyState(VK_CONTROL) & (1 << 15);
 
         switch (wparam)

--- a/demo/gdi/nuklear_gdi.h
+++ b/demo/gdi/nuklear_gdi.h
@@ -516,7 +516,7 @@ nk_gdi_handle_event(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
     case WM_SYSKEYDOWN:
     case WM_SYSKEYUP:
     {
-        int down = (lparam >> 31) & 1 ? 0 : 1;
+        int down = !((lparam >> 31) & 1);
         int ctrl = GetKeyState(VK_CONTROL) & (1 << 15);
 
         switch (wparam)

--- a/demo/gdip/nuklear_gdip.h
+++ b/demo/gdip/nuklear_gdip.h
@@ -754,7 +754,7 @@ nk_gdip_handle_event(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
     case WM_SYSKEYDOWN:
     case WM_SYSKEYUP:
     {
-        int down = (lparam >> 31) & 1 ? 0 : 1;
+        int down = !((lparam >> 31) & 1);
         int ctrl = GetKeyState(VK_CONTROL) & (1 << 15);
 
         switch (wparam)

--- a/demo/gdip/nuklear_gdip.h
+++ b/demo/gdip/nuklear_gdip.h
@@ -754,7 +754,7 @@ nk_gdip_handle_event(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
     case WM_SYSKEYDOWN:
     case WM_SYSKEYUP:
     {
-        int down = (lparam >> 31) & 1;
+        int down = (lparam >> 31) & 1 ? 0 : 1;
         int ctrl = GetKeyState(VK_CONTROL) & (1 << 15);
 
         switch (wparam)


### PR DESCRIPTION
There is a problem in the gdi, gdip and d3d11 demos.
The key reaction is occured at the timing of the control keys (cursor key, enter key, home key, etc) are released.
The cause is that the 'down' flag is reversed.

In nuklear_gdi.h, nuklear_gdip.h and nuklear_d3d11.h:
>int down = (lparam >> 31) & 1;

I think the following is correct:
>int down = (lparam >> 31) & 1 ? 0 : 1;

Because [MSDN](https://msdn.microsoft.com/ja-jp/library/windows/desktop/ms646280(v=vs.85).aspx) says:
>lParam Bits 31
>The value is always 0 for a WM_KEYDOWN message.
>The value is always 1 for a WM_KEYUP message.
>The value is always 0 for a WM_SYSKEYDOWN message.
>The value is always 1 for a WM_SYSKEYUP message.

See below for details.
Thanks.

![test_program](https://cloud.githubusercontent.com/assets/18512546/20303146/680cb85e-ab6d-11e6-8d18-13827ffb5914.png)
![before_fixing](https://cloud.githubusercontent.com/assets/18512546/20303151/6bcbd75e-ab6d-11e6-8c1a-a1d5339ba1a1.png)
![after_fixing](https://cloud.githubusercontent.com/assets/18512546/20303153/6e85f326-ab6d-11e6-9387-70667efe99e0.png)

