### PR TITLE
fix: popup border is not shown when using the default style settings

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -15645,6 +15645,7 @@ nk_style_from_table(struct nk_context *ctx, const struct nk_color *table)
     win->background = table[NK_COLOR_WINDOW];
     win->fixed_background = nk_style_item_color(table[NK_COLOR_WINDOW]);
     win->border_color = table[NK_COLOR_BORDER];
+    win->popup_border_color = table[NK_COLOR_BORDER];
     win->combo_border_color = table[NK_COLOR_BORDER];
     win->contextual_border_color = table[NK_COLOR_BORDER];
     win->menu_border_color = table[NK_COLOR_BORDER];
@@ -15662,6 +15663,7 @@ nk_style_from_table(struct nk_context *ctx, const struct nk_color *table)
     win->menu_border = 1.0f;
     win->group_border = 1.0f;
     win->tooltip_border = 1.0f;
+    win->popup_border = 1.0f;
     win->border = 2.0f;
 
     win->padding = nk_vec2(4,4);


### PR DESCRIPTION
Popup border is not shown in the default style settings.
I think, the initialization of popup border style is missing.
Specifically, although nk_popup_begin() specifies the NK_WINDOW_BORDER flag, nk_style_from_table() hasn't initialized win->popup_border_color and win->popup_border.

See below for details.
Thanks.

![before_fixing](https://cloud.githubusercontent.com/assets/18512546/20333207/5fb318c4-abf4-11e6-8052-6b7e0c914c3d.png)

![after_fixing](https://cloud.githubusercontent.com/assets/18512546/20333219/63a28bea-abf4-11e6-9ec2-a777a828f68d.png)
