### PR TITLE
Set window bounds in nk_begin when the window isn't user-resizable

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -17247,6 +17247,8 @@ nk_begin_titled(struct nk_context *ctx, const char *name, const char *title,
         /* update window */
         win->flags &= ~(nk_flags)(NK_WINDOW_PRIVATE-1);
         win->flags |= flags;
+        if (!(win->flags & (NK_WINDOW_MOVABLE | NK_WINDOW_SCALABLE)))
+            win->bounds = bounds;
         /* If this assert triggers you either:
          *
          * I.) Have more than one window with the same name or


### PR DESCRIPTION
As mentioned in https://github.com/vurtun/nuklear/issues/305