### PR TITLE
build fix for gcc

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -16058,7 +16058,7 @@ nk_clear(struct nk_context *ctx)
     while (iter) {
         /* make sure minimized windows do not get removed */
         if ((iter->flags & NK_WINDOW_MINIMIZED) &&
-            !(iter)->flags & NK_WINDOW_CLOSED) {
+            !(iter->flags & NK_WINDOW_CLOSED)) {
             iter = iter->next;
             continue;
         }


### PR DESCRIPTION
GCC on my travis.ci builder was complaining about the parens in this expression.

I believe the intent of the expression was to check if the window was `minimized && !closed`.