### PR TITLE
GDI+ images support

### DIFF
--- a/demo/gdip/build.bat
+++ b/demo/gdip/build.bat
@@ -2,4 +2,4 @@
 
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
 
-cl /nologo /W3 /O2 /fp:fast /Gm- /Fedemo.exe main.c user32.lib gdiplus.lib /link /incremental:no
+cl /nologo /W3 /O2 /fp:fast /Gm- /Fedemo.exe main.c user32.lib gdiplus.lib ole32.lib /link /incremental:no


### PR DESCRIPTION
There are 2 user functions added: `nk_gdip_load_image_from_file` and `nk_gdip_load_image_from_memory`. The second one requires function from `ole32.lib`
