### PR TITLE
Remove warning: 'nk_to_upper' defined but not used

### DIFF
--- a/demo/x11_opengl2/nuklear_xlib_gl2.h
+++ b/demo/x11_opengl2/nuklear_xlib_gl2.h
@@ -10,8 +10,8 @@
  *
  * ===============================================================
  */
-#ifndef NK_XLIB_GL3_H_
-#define NK_XLIB_GL3_H_
+#ifndef NK_XLIB_GL2_H_
+#define NK_XLIB_GL2_H_
 
 #include <X11/Xlib.h>
 NK_API struct nk_context*   nk_x11_init(Display *dpy, Window win);

--- a/nuklear.h
+++ b/nuklear.h
@@ -3740,7 +3740,7 @@ nk_strmatch_fuzzy_text(const char *str, int str_len,
 
         int next_match = *pattern_iter != '\0' &&
             nk_to_lower(pattern_letter) == nk_to_lower(str_letter);
-        int rematch = best_letter && nk_to_lower(*best_letter) == nk_to_lower(str_letter);
+        int rematch = best_letter && nk_to_upper(*best_letter) == nk_to_upper(str_letter);
 
         int advanced = next_match && best_letter;
         int pattern_repeat = best_letter && *pattern_iter != '\0';


### PR DESCRIPTION
There is function `NK_INTERN int nk_to_upper(int c)` in `UTIL` section. Implementation is almost the same to `NK_INTERN int nk_to_lower(int c)`. But only `nk_to_lower` used in Nuklear's code. To remove this warning we can: 
1) Comment i.e. remove `nk_to_upper` from code. But it can break someone's code, if he used it in module with `NK_IMPLEMENTATION` defined.
2) Hide it under define. Same. 
3) Just use it somewhere in code. 
I replaced two calls of `nk_to_lower` to `nk_to_upper`. It removes the warning, code works the same. The bad side - complication of the code. "Why `nk_to_upper` is used here, but not `nk_to_lower` as one line up?"
Maybe there exists better solution? Or just add the comment about this line to code?