### PR TITLE
Remove warning "unsigned only in ISO C90"

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -3140,7 +3140,7 @@ template<typename T> struct nk_alignof{struct Big {T x; char c;}; enum {
 #define NK_SINT_MIN (-2147483647)
 #define NK_SINT_MAX 2147483647
 #define NK_UINT_MIN 0
-#define NK_UINT_MAX 4294967295
+#define NK_UINT_MAX 4294967295u
 
 /* Make sure correct type size:
  * This will fire with a negative subscript error if the type sizes


### PR DESCRIPTION
These warnings appear on GCC for Windows only. There a lot of them. Doesn't matter, native compilation or crosscompile.
`nuklear.h:6836:9: warning: this decimal constant is unsigned only in ISO C90`