### PR TITLE
Fix panel clipping

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -16613,7 +16613,7 @@ nk_panel_begin(struct nk_context *ctx, const char *title, enum nk_panel_type pan
 
     /* set clipping rectangle */
     {struct nk_rect clip;
-    layout->clip = layout->bounds;
+    layout->clip = win->bounds;
     nk_unify(&clip, &win->buffer.clip, layout->clip.x, layout->clip.y,
         layout->clip.x + layout->clip.w, layout->clip.y + layout->clip.h);
     nk_push_scissor(out, clip);


### PR DESCRIPTION
`layout->bounds` cannot be used (loc 16615) since we modify it up here:
`layout->bounds.x += panel_padding.x;`  (16471)
`layout->bounds.w -= 2*panel_padding.x;` (16472)
Because of it there was no ability to `nk_draw_image` attached to window's edge. There alway was empty lines of right and left.

This code breaks the other's code. Popups, for example. My paddings are 10px. To show popup at (20,20) without this patch I must use `nk_rect(10, 20, ...`. With this patch I must use `nk_rect(20, 20, ...`, not depending on paddings. I think (20,20) is a correct constant for (20,20) coordinate.