### PR TITLE
Add Windows alternative to rm in Makefiles

### DIFF
--- a/demo/allegro5/Makefile
+++ b/demo/allegro5/Makefile
@@ -11,12 +11,13 @@ OBJ = $(SRC:.c=.o)
 #ifeq ($(OS),Windows_NT)
 #BIN := $(BIN).exe
 #LIBS = -lglfw3 -lopengl32 -lm -lGLU32 -lGLEW32
+#PRE := del bin\$(BIN) || rmdir /s /q bin || mkdir bin || rem
 #else
 LIBS = -lallegro -lallegro_main -lallegro_image -lallegro_font \
 	-lallegro_ttf -lallegro_primitives -lm
+PRE := rm -f bin/$(BIN) $(OBJS) && mkdir -p bin
 #endif
 
 $(BIN):
-	@mkdir -p bin
-	rm -f bin/$(BIN) $(OBJS)
+	$(PRE)
 	$(CC) $(SRC) $(CFLAGS) -o bin/$(BIN) $(LIBS)

--- a/demo/glfw_opengl2/Makefile
+++ b/demo/glfw_opengl2/Makefile
@@ -10,7 +10,9 @@ OBJ = $(SRC:.c=.o)
 ifeq ($(OS),Windows_NT)
 BIN := $(BIN).exe
 LIBS = -lglfw3 -lopengl32 -lm -lGLU32
+PRE := del bin\$(BIN) || rmdir /s /q bin || mkdir bin || rem
 else
+	PRE := rm -f bin/$(BIN) $(OBJS) && mkdir -p bin
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S),Darwin)
 		LIBS := -lglfw3 -framework OpenGL -framework Cocoa -framework IOKit -framework CoreVideo -lm -lGLEW -L/usr/local/lib
@@ -20,6 +22,5 @@ else
 endif
 
 $(BIN):
-	@mkdir -p bin
-	rm -f bin/$(BIN) $(OBJS)
+	$(PRE)
 	$(CC) $(SRC) $(CFLAGS) -o bin/$(BIN) $(LIBS)

--- a/demo/glfw_opengl3/Makefile
+++ b/demo/glfw_opengl3/Makefile
@@ -10,7 +10,9 @@ OBJ = $(SRC:.c=.o)
 ifeq ($(OS),Windows_NT)
 BIN := $(BIN).exe
 LIBS = -lglfw3 -lopengl32 -lm -lGLU32 -lGLEW32
+PRE := del bin\$(BIN) || rmdir /s /q bin || mkdir bin || rem
 else
+	PRE := rm -f bin/$(BIN) $(OBJS) && mkdir -p bin
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S),Darwin)
 		LIBS := -lglfw3 -framework OpenGL -framework Cocoa -framework IOKit -framework CoreVideo -lm -lGLEW -L/usr/local/lib
@@ -20,6 +22,5 @@ else
 endif
 
 $(BIN):
-	@mkdir -p bin
-	rm -f bin/$(BIN) $(OBJS)
+	$(PRE)
 	$(CC) $(SRC) $(CFLAGS) -o bin/$(BIN) $(LIBS)

--- a/demo/sdl_opengl2/Makefile
+++ b/demo/sdl_opengl2/Makefile
@@ -10,7 +10,9 @@ OBJ = $(SRC:.c=.o)
 ifeq ($(OS),Windows_NT)
 BIN := $(BIN).exe
 LIBS = -lmingw32 -lSDL2main -lSDL2 -lopengl32 -lm -lGLU32
+PRE := del bin\$(BIN) || rmdir /s /q bin || mkdir bin || rem
 else
+	PRE := rm -f bin/$(BIN) $(OBJS) && mkdir -p bin
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S),Darwin)
 		LIBS = -lSDL2 -framework OpenGL -lm
@@ -20,6 +22,5 @@ else
 endif
 
 $(BIN):
-	@mkdir -p bin
-	rm -f bin/$(BIN) $(OBJS)
+	$(PRE)
 	$(CC) $(SRC) $(CFLAGS) -o bin/$(BIN) $(LIBS)

--- a/demo/sdl_opengl3/Makefile
+++ b/demo/sdl_opengl3/Makefile
@@ -10,7 +10,9 @@ OBJ = $(SRC:.c=.o)
 ifeq ($(OS),Windows_NT)
 BIN := $(BIN).exe
 LIBS = -lmingw32 -lSDL2main -lSDL2 -lopengl32 -lm -lGLU32 -lGLEW32
+PRE := del bin\$(BIN) || rmdir /s /q bin || mkdir bin || rem
 else
+	PRE := rm -f bin/$(BIN) $(OBJS) && mkdir -p bin
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S),Darwin)
 		LIBS = -lSDL2 -framework OpenGL -lm -lGLEW
@@ -20,6 +22,5 @@ else
 endif
 
 $(BIN):
-	@mkdir -p bin
-	rm -f bin/$(BIN) $(OBJS)
+	$(PRE)
 	$(CC) $(SRC) $(CFLAGS) -o bin/$(BIN) $(LIBS)


### PR DESCRIPTION
There's a little bit different handling of file/folder removal on Windows and it makes MinGW/GCC fail with annoying errors forcing a user to compile by hand. The problem mostly isn't the first compile, rather the _second_ (after the files are created).

Also, every bad error code kills make, therefore a user has to silence them if not successful, otherwise there will be no compilation and the make will just die because e.g. there already is a `bin` folder or something else.

The Makefiles however won't work with `nmake.exe`, which is MS alternative to GNU make, because the syntax is a little bit different, sadly.

**Edit:** Also it's good to mention that `$(CC)` returns (at least on Windows) just "cc", which maybe works somewhere, fails with `gcc.exe` and I believe it could fail on linux too.