### PR TITLE
Fix unary operator clang warning

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -16901,7 +16901,7 @@ nk_panel_end(struct nk_context *ctx)
             if (nk_input_is_mouse_down(in, NK_BUTTON_LEFT) && left_mouse_down && left_mouse_click_in_scaler) {
                 float delta_x = in->mouse.delta.x;
                 if (layout->flags & NK_WINDOW_SCALE_LEFT) {
-                    delta_x =- delta_x;
+                    delta_x = -delta_x;
                     window->bounds.x += in->mouse.delta.x;
                 }
                 window->bounds.w = NK_MAX(window_size.x, window->bounds.w + delta_x);


### PR DESCRIPTION
Clang warns for `=+`, `=-`