### PR TITLE
Remove const cast of endptr in nk_strto* functions

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -1135,9 +1135,8 @@ NK_API struct nk_vec2           nk_rect_size(struct nk_rect);
 NK_API int                      nk_strlen(const char *str);
 NK_API int                      nk_stricmp(const char *s1, const char *s2);
 NK_API int                      nk_stricmpn(const char *s1, const char *s2, int n);
-NK_API int                      nk_strtoi(const char *str, char **endptr);
-NK_API float                    nk_strtof(const char *str, char **endptr);
-NK_API double                   nk_strtod(const char *str, char **endptr);
+NK_API int                      nk_strtoi(const char *str, const char **endptr);
+NK_API float                    nk_strtof(const char *str, const char **endptr);
 NK_API int                      nk_strfilter(const char *text, const char *regexp);
 NK_API int                      nk_strmatch_fuzzy_string(char const *str, char const *pattern, int *out_score);
 NK_API int                      nk_strmatch_fuzzy_text(const char *txt, int txt_len, const char *pattern, int *out_score);
@@ -3530,7 +3529,7 @@ nk_strlen(const char *str)
 }
 
 NK_API int
-nk_strtoi(const char *str, char **endptr)
+nk_strtoi(const char *str, const char **endptr)
 {
     int neg = 1;
     const char *p = str;
@@ -3550,12 +3549,12 @@ nk_strtoi(const char *str, char **endptr)
         p++;
     }
     if (endptr)
-        *endptr = (char*)p;
+        *endptr = p;
     return neg*value;
 }
 
 NK_API double
-nk_strtod(const char *str, char **endptr)
+nk_strtod(const char *str, const char **endptr)
 {
     double m;
     double neg = 1.0;
@@ -3608,12 +3607,12 @@ nk_strtod(const char *str, char **endptr)
     }
     number = value * neg;
     if (endptr)
-        *endptr = (char*)p;
+        *endptr = p;
     return number;
 }
 
 NK_API float
-nk_strtof(const char *str, char **endptr)
+nk_strtof(const char *str, const char **endptr)
 {
     float float_value;
     double double_value;


### PR DESCRIPTION
Change `endptr` to `const char **` and avoid const cast.
Should not break existing code passing `char **` as `endptr`.