### PR TITLE
fix: warning unused variable in nk_finish()

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -16239,8 +16239,6 @@ nk_finish(struct nk_context *ctx, struct nk_window *win)
 {
     struct nk_popup_buffer *buf;
     struct nk_command *parent_last;
-    struct nk_command *sublast;
-    struct nk_command *last;
     void *memory;
 
     NK_ASSERT(ctx);


### PR DESCRIPTION
Hello.

In revision 1a87c13, gcc generates the warnings in the function nk_finish():

> warning: unused variable `last'

> warning: unused variable `sublast'

I fixed it. Thanks.
