### PR TITLE
Several fixes

### DIFF
--- a/example/canvas.c
+++ b/example/canvas.c
@@ -307,7 +307,7 @@ static void error_callback(int e, const char *d){printf("Error %d: %s\n", e, d);
 static void text_input(GLFWwindow *win, unsigned int codepoint)
 {nk_input_unicode((struct nk_context*)glfwGetWindowUserPointer(win), codepoint);}
 static void scroll_input(GLFWwindow *win, double _, double yoff)
-{UNUSED(_);nk_input_scroll((struct nk_context*)glfwGetWindowUserPointer(win), (float)yoff);}
+{UNUSED(_);nk_input_scroll((struct nk_context*)glfwGetWindowUserPointer(win), nk_vec2(0, (float)yoff));}
 
 static void
 pump_input(struct nk_context *ctx, GLFWwindow *win)

--- a/example/extended.c
+++ b/example/extended.c
@@ -734,7 +734,7 @@ static void error_callback(int e, const char *d){printf("Error %d: %s\n", e, d);
 static void text_input(GLFWwindow *win, unsigned int codepoint)
 {nk_input_unicode((struct nk_context*)glfwGetWindowUserPointer(win), codepoint);}
 static void scroll_input(GLFWwindow *win, double _, double yoff)
-{UNUSED(_);nk_input_scroll((struct nk_context*)glfwGetWindowUserPointer(win), (float)yoff);}
+{UNUSED(_);nk_input_scroll((struct nk_context*)glfwGetWindowUserPointer(win), nk_vec2(0, (float)yoff));}
 
 int main(int argc, char *argv[])
 {

--- a/example/file_browser.c
+++ b/example/file_browser.c
@@ -765,7 +765,7 @@ static void error_callback(int e, const char *d){printf("Error %d: %s\n", e, d);
 static void text_input(GLFWwindow *win, unsigned int codepoint)
 {nk_input_unicode((struct nk_context*)glfwGetWindowUserPointer(win), codepoint);}
 static void scroll_input(GLFWwindow *win, double _, double yoff)
-{UNUSED(_);nk_input_scroll((struct nk_context*)glfwGetWindowUserPointer(win), (float)yoff);}
+{UNUSED(_);nk_input_scroll((struct nk_context*)glfwGetWindowUserPointer(win), nk_vec2(0, (float)yoff));}
 
 int main(int argc, char *argv[])
 {

--- a/example/skinning.c
+++ b/example/skinning.c
@@ -334,7 +334,7 @@ static void error_callback(int e, const char *d){printf("Error %d: %s\n", e, d);
 static void text_input(GLFWwindow *win, unsigned int codepoint)
 {nk_input_unicode((struct nk_context*)glfwGetWindowUserPointer(win), codepoint);}
 static void scroll_input(GLFWwindow *win, double _, double yoff)
-{UNUSED(_);nk_input_scroll((struct nk_context*)glfwGetWindowUserPointer(win), (float)yoff);}
+{UNUSED(_);nk_input_scroll((struct nk_context*)glfwGetWindowUserPointer(win), nk_vec2(0, (float)yoff));}
 
 int main(int argc, char *argv[])
 {

--- a/nuklear.h
+++ b/nuklear.h
@@ -13760,7 +13760,7 @@ nk_scrollbar_behavior(nk_flags *state, struct nk_input *in,
     const struct nk_rect *empty1, float scroll_offset,
     float target, float scroll_step, enum nk_orientation o)
 {
-    nk_flags ws;
+    nk_flags ws = 0;
     int left_mouse_down;
     int left_mouse_click_in_cursor;
     float scroll_delta;


### PR DESCRIPTION
Fixed examples using `nk_input_scroll()` api properly.

~~Fixed memory leak in `nk_draw_list_path_line_to()` - points were allocated but not really used.~~ Well looks like it had side-effects. AddressSanitizer still reports it as a memory leak though..

Initialized `ws` variable to 0 in `nk_scrollbar_behavior()`. Uninitialized variable was being passed to `nk_button_behavior()` which performed `nk_widget_state_reset(state)0;` on it which expands to if/else.

So thats that, some low-hanging fruits pointed out by AddressSanitizer.