### PR TITLE
Fix gcc warning in nk_end().

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -17427,7 +17427,7 @@ nk_end(struct nk_context *ctx)
         return;
 
     layout = ctx->current->layout;
-    if (!layout || layout->type == NK_PANEL_WINDOW && (ctx->current->flags & NK_WINDOW_HIDDEN)) {
+    if (!layout || (layout->type == NK_PANEL_WINDOW && (ctx->current->flags & NK_WINDOW_HIDDEN))) {
         ctx->current = 0;
         return;
     }


### PR DESCRIPTION
Hello.
In revision 274d9c4, gcc 2.7.2 generates a warning in the function nk_end():

> warning: suggest parentheses around && within ||

I fixed it. Thanks.
