### PR TITLE
Add software rasterizer library and demo.

### DIFF
--- a/demo/x11_rawfb/Makefile
+++ b/demo/x11_rawfb/Makefile
@@ -1,0 +1,13 @@
+# Install
+BIN = zahnrad
+
+# Flags
+CFLAGS = -std=c89 -pedantic -O2 -Wunused -DRAWFB_XRGB_8888
+
+SRC = main.c
+OBJ = $(SRC:.c=.o)
+
+$(BIN):
+	@mkdir -p bin
+	rm -f bin/$(BIN) $(OBJS)
+	$(CC) $(SRC) $(CFLAGS) -D_GNU_SOURCE -D_POSIX_C_SOURCE=200809L -o bin/$(BIN) -lX11 -lXext -lm

--- a/demo/x11_rawfb/main.c
+++ b/demo/x11_rawfb/main.c
@@ -1,0 +1,221 @@
+/* nuklear - v1.17 - public domain */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <string.h>
+#include <limits.h>
+#include <math.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <time.h>
+
+#define NK_INCLUDE_FIXED_TYPES
+#define NK_INCLUDE_STANDARD_IO
+#define NK_INCLUDE_STANDARD_VARARGS
+#define NK_INCLUDE_DEFAULT_ALLOCATOR
+#define NK_IMPLEMENTATION
+#define NK_XLIBSHM_IMPLEMENTATION
+#define NK_RAWFB_IMPLEMENTATION
+#define NK_INCLUDE_FONT_BAKING
+#define NK_INCLUDE_DEFAULT_FONT
+#define NK_INCLUDE_SOFTWARE_FONT
+
+#include "../../nuklear.h"
+#include "nuklear_rawfb.h"
+#include "nuklear_xlib.h"
+
+#define DTIME           20
+#define WINDOW_WIDTH    800
+#define WINDOW_HEIGHT   600
+
+#define UNUSED(a) (void)a
+#define MIN(a,b) ((a) < (b) ? (a) : (b))
+#define MAX(a,b) ((a) < (b) ? (b) : (a))
+#define LEN(a) (sizeof(a)/sizeof(a)[0])
+
+typedef struct XWindow XWindow;
+struct XWindow {
+    Display *dpy;
+    Window root;
+    Visual *vis;
+    Colormap cmap;
+    XWindowAttributes attr;
+    XSetWindowAttributes swa;
+    Window win;
+    int screen;
+    unsigned int width;
+    unsigned int height;
+};
+
+static void
+die(const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    va_end(ap);
+    fputs("\n", stderr);
+    exit(EXIT_FAILURE);
+}
+
+static void*
+xcalloc(size_t siz, size_t n)
+{
+    void *ptr = calloc(siz, n);
+    if (!ptr) die("Out of memory\n");
+    return ptr;
+}
+
+static long
+timestamp(void)
+{
+    struct timeval tv;
+    if (gettimeofday(&tv, NULL) < 0) return 0;
+    return (long)((long)tv.tv_sec * 1000 + (long)tv.tv_usec/1000);
+}
+
+static void
+sleep_for(long t)
+{
+    struct timespec req;
+    const time_t sec = (int)(t/1000);
+    const long ms = t - (sec * 1000);
+    req.tv_sec = sec;
+    req.tv_nsec = ms * 1000000L;
+    while(-1 == nanosleep(&req, &req));
+}
+
+/* ===============================================================
+ *
+ *                          EXAMPLE
+ *
+ * ===============================================================*/
+/* This are some code examples to provide a small overview of what can be
+ * done with this library. To try out an example uncomment the include
+ * and the corresponding function. */
+/*#include "../style.c"*/
+/*#include "../calculator.c"*/
+#include "../overview.c"
+#include "../node_editor.c"
+
+/* ===============================================================
+ *
+ *                          DEMO
+ *
+ * ===============================================================*/
+int
+main(void)
+{
+    long dt;
+    long started;
+    int running = 1;
+    int status;
+    XWindow xw;
+    struct rawfb_context *rawfb;
+    void *fb = NULL;
+    unsigned char tex_scratch[512 * 512];
+    XSizeHints hints;
+
+    /* X11 */
+    memset(&xw, 0, sizeof xw);
+    xw.dpy = XOpenDisplay(NULL);
+    if (!xw.dpy) die("Could not open a display; perhaps $DISPLAY is not set?");
+
+    xw.root = DefaultRootWindow(xw.dpy);
+    xw.screen = XDefaultScreen(xw.dpy);
+    xw.vis = XDefaultVisual(xw.dpy, xw.screen);
+    xw.cmap = XCreateColormap(xw.dpy,xw.root,xw.vis,AllocNone);
+    xw.swa.colormap = xw.cmap;
+    xw.swa.event_mask =
+        ExposureMask | KeyPressMask | KeyReleaseMask |
+        ButtonPress | ButtonReleaseMask| ButtonMotionMask |
+        Button1MotionMask | Button3MotionMask | Button4MotionMask | Button5MotionMask|
+        PointerMotionMask | KeymapStateMask | EnterWindowMask | LeaveWindowMask;
+    xw.win = XCreateWindow(xw.dpy, xw.root, 0, 0, WINDOW_WIDTH, WINDOW_HEIGHT, 0,
+        XDefaultDepth(xw.dpy, xw.screen), InputOutput,
+        xw.vis, CWEventMask | CWColormap, &xw.swa);
+
+    XStoreName(xw.dpy, xw.win, "X11");
+    XMapWindow(xw.dpy, xw.win);
+    XGetWindowAttributes(xw.dpy, xw.win, &xw.attr);
+    xw.width = (unsigned int)xw.attr.width;
+    xw.height = (unsigned int)xw.attr.height;
+
+    /* Framebuffer emulator */
+    status = nk_xlib_init(xw.dpy, xw.vis, xw.screen, xw.win, xw.width, xw.height, &fb);
+    if (!status || !fb)
+        return 0;
+
+    /* GUI */
+    rawfb = nk_rawfb_init(fb, tex_scratch, xw.width, xw.height, xw.width * 4);
+    if (!rawfb)
+        running = 0;
+
+    /* style.c */
+    /*set_style(ctx, THEME_WHITE);*/
+    /*set_style(ctx, THEME_RED);*/
+    /*set_style(ctx, THEME_BLUE);*/
+    /*set_style(ctx, THEME_DARK);*/
+
+    while (running) {
+        /* Input */
+        XEvent evt;
+        started = timestamp();
+        nk_input_begin(&rawfb->ctx);
+        while (XCheckWindowEvent(xw.dpy, xw.win, xw.swa.event_mask, &evt)) {
+            if (XFilterEvent(&evt, xw.win)) continue;
+            nk_xlib_handle_event(xw.dpy, xw.screen, xw.win, &evt, rawfb);
+        }
+        nk_input_end(&rawfb->ctx);
+
+        /* GUI */
+        if (nk_begin(&rawfb->ctx, "Demo", nk_rect(50, 50, 200, 200),
+            NK_WINDOW_BORDER|NK_WINDOW_MOVABLE|
+            NK_WINDOW_CLOSABLE|NK_WINDOW_MINIMIZABLE|NK_WINDOW_TITLE)) {
+            enum {EASY, HARD};
+            static int op = EASY;
+            static int property = 20;
+
+            nk_layout_row_static(&rawfb->ctx, 30, 80, 1);
+            if (nk_button_label(&rawfb->ctx, "button"))
+                fprintf(stdout, "button pressed\n");
+            nk_layout_row_dynamic(&rawfb->ctx, 30, 2);
+            if (nk_option_label(&rawfb->ctx, "easy", op == EASY)) op = EASY;
+            if (nk_option_label(&rawfb->ctx, "hard", op == HARD)) op = HARD;
+            nk_layout_row_dynamic(&rawfb->ctx, 25, 1);
+            nk_property_int(&rawfb->ctx, "Compression:", 0, &property, 100, 10, 1);
+        }
+        nk_end(&rawfb->ctx);
+        if (nk_window_is_closed(&rawfb->ctx, "Demo")) break;
+
+        /* -------------- EXAMPLES ---------------- */
+        /*calculator(ctx);*/
+        overview(&rawfb->ctx);
+        node_editor(&rawfb->ctx);
+        /* ----------------------------------------- */
+
+        /* Draw framebuffer */
+        nk_rawfb_render(rawfb, nk_rgb(30,30,30), 1);
+
+        /* Emulate framebuffer */
+        XClearWindow(xw.dpy, xw.win);
+        nk_xlib_render(xw.win);
+
+        XFlush(xw.dpy);
+
+        /* Timing */
+        dt = timestamp() - started;
+        if (dt < DTIME)
+            sleep_for(DTIME - dt);
+    }
+
+    nk_rawfb_shutdown(rawfb);
+    nk_xlib_shutdown();
+    XUnmapWindow(xw.dpy, xw.win);
+    XFreeColormap(xw.dpy, xw.cmap);
+    XDestroyWindow(xw.dpy, xw.win);
+    XCloseDisplay(xw.dpy);
+    return 0;
+}
+

--- a/demo/x11_rawfb/nuklear_rawfb.h
+++ b/demo/x11_rawfb/nuklear_rawfb.h
@@ -1,0 +1,1150 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2016-2017 Patrick Rudolph <siro@das-labor.org>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+*/
+/*
+ * ==============================================================
+ *
+ *                              API
+ *
+ * ===============================================================
+ */
+#ifndef NK_RAWFB_H_
+#define NK_RAWFB_H_
+
+struct rawfb_context;
+
+/* All functions are thread-safe */
+NK_API struct rawfb_context *nk_rawfb_init(void *fb, void *tex_mem, const unsigned int w, const unsigned int h, const unsigned int pitch);
+NK_API void                  nk_rawfb_render(const struct rawfb_context *rawfb, const struct nk_color clear, const unsigned char enable_clear);
+NK_API void                  nk_rawfb_shutdown(struct rawfb_context *rawfb);
+NK_API void                  nk_rawfb_resize_fb(struct rawfb_context *rawfb, void *fb, const unsigned int w, const unsigned int h, const unsigned int pitch);
+
+#endif
+/*
+ * ==============================================================
+ *
+ *                          IMPLEMENTATION
+ *
+ * ===============================================================
+ */
+#ifdef NK_RAWFB_IMPLEMENTATION
+
+struct rawfb_image {
+    void *pixels;
+    int w;
+    int h;
+    int pitch;
+    enum nk_font_atlas_format format;
+};
+
+struct rawfb_context {
+    struct nk_context ctx;
+    struct nk_rect scissors;
+    struct rawfb_image fb;
+    struct rawfb_image font_tex;
+    struct nk_font_atlas atlas;
+};
+
+#ifndef MIN
+#define MIN(a,b) ((a) < (b) ? (a) : (b))
+#endif
+#ifndef MAX
+#define MAX(a,b) ((a) < (b) ? (b) : (a))
+#endif
+
+static unsigned int
+nk_color_from_byte(const nk_byte *c)
+{
+    unsigned int res = 0;
+#if defined(RAWFB_RGBX_8888)
+    res |= (unsigned int)c[0] << 16;
+    res |= (unsigned int)c[1] << 8;
+    res |= (unsigned int)c[2] << 0;
+#elif defined(RAWFB_XRGB_8888)
+    res = ((unsigned int *)c)[0];
+#else
+#error Define one of RAWFB_RGBX_8888 , RAWFB_XRGB_8888
+#endif
+    return (res);
+}
+
+static void
+nk_rawfb_setpixel(const struct rawfb_context *rawfb,
+                  const short x0,
+                  const short y0,
+                  const struct nk_color col)
+{
+    unsigned int c = nk_color_from_byte(&col.r);
+    unsigned int *ptr = (unsigned int *)rawfb->fb.pixels;
+
+    ptr += y0 * rawfb->fb.w;
+    ptr += x0;
+
+    if (y0 < rawfb->scissors.h && y0 >= rawfb->scissors.y &&
+        x0 >= rawfb->scissors.x && x0 < rawfb->scissors.w)
+        *ptr = c;
+}
+
+/*
+ * This function is called the most. Try to optimize it a bit...
+ *
+ * It does not check for scissors or image borders.
+ * The caller has to make sure it does no exceed bounds.
+ */
+static void
+nk_rawfb_line_horizontal(const struct rawfb_context *rawfb,
+                         const short x0,
+                         const short y,
+                         const short x1,
+                         const struct nk_color col)
+{
+    unsigned int i, n;
+    unsigned int c[16];
+    unsigned int *ptr = (unsigned int *)rawfb->fb.pixels;
+
+    ptr += y * rawfb->fb.w;
+    ptr += x0;
+
+    n = x1 - x0;
+
+    for (i = 0; i < sizeof(c) / sizeof(c[0]); i++)
+        c[i] = nk_color_from_byte(&col.r);
+
+    while (n > 16) {
+        memcpy((void *)ptr, c, sizeof(c));
+        n -= 16;
+        ptr += 16;
+    }
+
+    for (i = 0; i < n; i++)
+        ptr[i] = c[i];
+}
+
+static void
+nk_rawfb_imagesetpixel(const struct rawfb_image *img,
+                       const int x0,
+                       const int y0,
+                       const struct nk_color col)
+{
+    unsigned char *ptr;
+
+    NK_ASSERT(img);
+
+    if (y0 < img->h && y0 > 0 && x0 > 0 && x0 < img->w) {
+        ptr = img->pixels;
+
+        if (img->format == NK_FONT_ATLAS_ALPHA8) {
+            ptr += img->pitch * y0;
+            ptr[x0] = col.a;
+        } else {
+            ptr += img->pitch * y0;
+            ((struct nk_color *)ptr)[x0] = col;
+        }
+    }
+}
+
+static struct nk_color
+nk_image_getpixel(const struct rawfb_image *img,
+                  const int x0,
+                  const int y0)
+{
+    struct nk_color col = {0, 0, 0, 0};
+    unsigned char *ptr;
+
+    NK_ASSERT(img);
+
+    if (y0 < img->h && y0 > 0 && x0 > 0 && x0 < img->w) {
+        ptr = img->pixels;
+
+        if (img->format == NK_FONT_ATLAS_ALPHA8) {
+            ptr += img->pitch * y0;
+            col.a = ptr[x0];
+            col.b = col.g = col.r = 0xff;
+        } else {
+            ptr += img->pitch * y0;
+            col = ((struct nk_color *)ptr)[x0];
+        }
+    }
+
+    return col;
+}
+
+static void
+nk_image_blendpixel(const struct rawfb_image *img,
+                    const int x0,
+                    const int y0,
+                    struct nk_color col)
+{
+    struct nk_color col2;
+    unsigned char inv_a;
+
+    if (col.a == 0)
+        return;
+
+    inv_a = 0xff - col.a;
+
+    col2 = nk_image_getpixel(img, x0, y0);
+
+    col.r = (col.r * col.a + col2.r * inv_a) >> 8;
+    col.g = (col.g * col.a + col2.g * inv_a) >> 8;
+    col.b = (col.b * col.a + col2.b * inv_a) >> 8;
+
+    nk_rawfb_imagesetpixel(img, x0, y0, col);
+}
+
+static void
+nk_rawfb_scissor(struct rawfb_context *rawfb,
+                 const float x,
+                 const float y,
+                 const float w,
+                 const float h)
+{
+    rawfb->scissors.x = MIN(MAX(x, 0), rawfb->fb.w);
+    rawfb->scissors.y = MIN(MAX(y, 0), rawfb->fb.h);
+    rawfb->scissors.w = MIN(MAX(w + x, 0), rawfb->fb.w);
+    rawfb->scissors.h = MIN(MAX(h + y, 0), rawfb->fb.h);
+}
+
+static void
+nk_rawfb_stroke_line(const struct rawfb_context *rawfb,
+                     short x0,
+                     short y0,
+                     short x1,
+                     short y1,
+                     const unsigned int line_thickness,
+                     const struct nk_color col)
+{
+    int dy, dx, stepx, stepy;
+    short tmp;
+
+    dy = y1 - y0;
+    dx = x1 - x0;
+
+    /* fast path */
+    if (dy == 0) {
+        if (dx == 0 || y0 >= rawfb->scissors.h || y0 < rawfb->scissors.y)
+            return;
+
+        if (dx < 0) {
+            /* swap x0 and x1 */
+            tmp = x1;
+            x1 = x0;
+            x0 = tmp;
+        }
+
+        x1 = MIN(rawfb->scissors.w - 1, x1);
+        x0 = MIN(rawfb->scissors.w - 1, x0);
+        x1 = MAX(rawfb->scissors.x, x1);
+        x0 = MAX(rawfb->scissors.x, x0);
+
+        nk_rawfb_line_horizontal(rawfb, x0, y0, x1, col);
+
+        return;
+    }
+
+    if (dy < 0) {
+        dy = -dy;
+        stepy = -1;
+    } else {
+        stepy = 1;
+    }
+
+    if (dx < 0) {
+        dx = -dx;
+        stepx = -1;
+    } else {
+        stepx = 1;
+    }
+
+    dy <<= 1;
+    dx <<= 1;
+
+    nk_rawfb_setpixel(rawfb, x0, y0, col);
+
+    if (dx > dy) {
+        int fraction = dy - (dx >> 1);
+        while (x0 != x1) {
+            if (fraction >= 0) {
+                y0 += stepy;
+                fraction -= dx;
+            }
+            x0 += stepx;
+            fraction += dy;
+            nk_rawfb_setpixel(rawfb, x0, y0, col);
+        }
+    } else {
+        int fraction = dx - (dy >> 1);
+        while (y0 != y1) {
+            if (fraction >= 0) {
+                x0 += stepx;
+                fraction -= dy;
+            }
+            y0 += stepy;
+            fraction += dx;
+            nk_rawfb_setpixel(rawfb, x0, y0, col);
+        }
+    }
+}
+
+static void
+nk_rawfb_fill_polygon(const struct rawfb_context *rawfb,
+                      const struct nk_vec2i *pnts,
+                      int count,
+                      const struct nk_color col)
+{
+#define MAX_POINTS 64
+
+    int i = 0;
+    int left = 10000, top = 10000, bottom = 0, right = 0;
+    int  nodes, nodeX[MAX_POINTS], pixelX, pixelY, j, swap ;
+
+    if (count == 0)
+        return;
+    if (count > MAX_POINTS)
+        count = MAX_POINTS;
+
+    /* Get polygon dimensions */
+    for (i = 0; i < count; i++) {
+        if (left > pnts[i].x)
+            left = pnts[i].x;
+        if (right < pnts[i].x)
+            right = pnts[i].x;
+        if (top > pnts[i].y)
+            top = pnts[i].y;
+        if (bottom < pnts[i].y)
+            bottom = pnts[i].y;
+    }
+
+    bottom ++;
+    right ++;
+    /* Polygon scanline algorithm released under public-domain by Darel Rex Finley, 2007 */
+
+    /*  Loop through the rows of the image. */
+    for (pixelY = top; pixelY < bottom; pixelY ++) {
+        /*  Build a list of nodes. */
+        nodes = 0;
+        j = count - 1;
+        for (i = 0; i < count; i++) {
+            if (((pnts[i].y < pixelY) && (pnts[j].y >= pixelY))
+                 ||  ((pnts[j].y < pixelY) && (pnts[i].y >= pixelY))) {
+                nodeX[nodes++]=
+                    (int) ((float)pnts[i].x +
+                     ((float)pixelY - (float)pnts[i].y) / ((float)pnts[j].y - (float)pnts[i].y)
+                     * ((float)pnts[j].x - (float)pnts[i].x));
+            }
+            j = i;
+        }
+
+        /*  Sort the nodes, via a simple “Bubble” sort. */
+        i = 0;
+        while (i < nodes - 1) {
+            if (nodeX[i] > nodeX[i+1]) {
+                swap = nodeX[i];
+                nodeX[i] = nodeX[i+1];
+                nodeX[i+1] = swap;
+                if (i)
+                    i--;
+            } else {
+                i++;
+            }
+        }
+
+        /*  Fill the pixels between node pairs. */
+        for (i = 0; i < nodes; i += 2) {
+            if (nodeX[i    ] >= right)
+                break;
+            if (nodeX[i + 1] >  left) {
+                if (nodeX[i    ] < left)
+                    nodeX[i    ]= left ;
+                if (nodeX[i + 1] > right)
+                    nodeX[i + 1]= right;
+                for (pixelX = nodeX[i]; pixelX < nodeX[i + 1]; pixelX++)
+                    nk_rawfb_setpixel(rawfb, pixelX, pixelY, col);
+            }
+        }
+    }
+
+    #undef MAX_POINTS
+}
+
+
+static void
+nk_rawfb_stroke_arc(const struct rawfb_context *rawfb,
+                    short x0,
+                    short y0,
+                    short w,
+                    short h,
+                    const short s,
+                    const short line_thickness,
+                    const struct nk_color col)
+{
+    /* Bresenham's ellipses - modified to draw one quarter */
+    const int a2 = (w * w) / 4;
+    const int b2 = (h * h) / 4;
+    const int fa2 = 4 * a2, fb2 = 4 * b2;
+    int x, y, sigma;
+
+    if (s != 0 && s != 90 && s != 180 && s != 270)
+        return;
+
+    if (w < 1 || h < 1)
+        return;
+
+    /* Convert upper left to center */
+    h = (h + 1) / 2;
+    w = (w + 1) / 2;
+    x0 += w;
+    y0 += h;
+
+    /* First half */
+    for (x = 0, y = h, sigma = 2*b2+a2*(1-2*h); b2*x <= a2*y; x++) {
+        if (s == 180)
+            nk_rawfb_setpixel(rawfb, x0 + x, y0 + y, col);
+        else if (s == 270)
+            nk_rawfb_setpixel(rawfb, x0 - x, y0 + y, col);
+        else if (s == 0)
+            nk_rawfb_setpixel(rawfb, x0 + x, y0 - y, col);
+        else if (s == 90)
+            nk_rawfb_setpixel(rawfb, x0 - x, y0 - y, col);
+        if (sigma >= 0) {
+            sigma += fa2 * (1 - y);
+            y--;
+        }
+        sigma += b2 * ((4 * x) + 6);
+    }
+
+    /* Second half */
+    for (x = w, y = 0, sigma = 2*a2+b2*(1-2*w); a2*y <= b2*x; y++) {
+        if (s == 180)
+            nk_rawfb_setpixel(rawfb, x0 + x, y0 + y, col);
+        else if (s == 270)
+            nk_rawfb_setpixel(rawfb, x0 - x, y0 + y, col);
+        else if (s == 0)
+            nk_rawfb_setpixel(rawfb, x0 + x, y0 - y, col);
+        else if (s == 90)
+            nk_rawfb_setpixel(rawfb, x0 - x, y0 - y, col);
+        if (sigma >= 0) {
+            sigma += fb2 * (1 - x);
+            x--;
+        }
+        sigma += a2 * ((4 * y) + 6);
+    }
+}
+
+static void
+nk_rawfb_fill_arc(const struct rawfb_context *rawfb,
+                  short x0,
+                  short y0,
+                  short w,
+                  short h,
+                  const short s,
+                  const struct nk_color col)
+{
+    /* Bresenham's ellipses - modified to fill one quarter */
+    const int a2 = (w * w) / 4;
+    const int b2 = (h * h) / 4;
+    const int fa2 = 4 * a2, fb2 = 4 * b2;
+    int x, y, sigma;
+    struct nk_vec2i pnts[3];
+
+    if (s != 0 && s != 90 && s != 180 && s != 270)
+        return;
+
+    if (w < 1 || h < 1)
+        return;
+
+    /* Convert upper left to center */
+    h = (h + 1) / 2;
+    w = (w + 1) / 2;
+    x0 += w;
+    y0 += h;
+
+    pnts[0].x = x0;
+    pnts[0].y = y0;
+    pnts[2].x = x0;
+    pnts[2].y = y0;
+    /* First half */
+    for (x = 0, y = h, sigma = 2*b2+a2*(1-2*h); b2*x <= a2*y; x++) {
+        if (s == 180) {
+            pnts[1].x = x0 + x; pnts[1].y = y0 + y;
+        } else if (s == 270) {
+            pnts[1].x = x0 - x; pnts[1].y = y0 + y;
+        } else if (s == 0) {
+            pnts[1].x = x0 + x; pnts[1].y = y0 - y;
+        } else if (s == 90) {
+            pnts[1].x = x0 - x; pnts[1].y = y0 - y;
+        }
+
+        nk_rawfb_fill_polygon(rawfb, pnts, 3, col);
+        pnts[2] = pnts[1];
+
+        if (sigma >= 0) {
+            sigma += fa2 * (1 - y);
+            y--;
+        }
+        sigma += b2 * ((4 * x) + 6);
+    }
+
+    /* Second half */
+    for (x = w, y = 0, sigma = 2*a2+b2*(1-2*w); a2*y <= b2*x; y++) {
+        if (s == 180) {
+            pnts[1].x = x0 + x; pnts[1].y = y0 + y;
+        } else if (s == 270) {
+            pnts[1].x = x0 - x; pnts[1].y = y0 + y;
+        } else if (s == 0) {
+            pnts[1].x = x0 + x; pnts[1].y = y0 - y;
+        } else if (s == 90) {
+            pnts[1].x = x0 - x; pnts[1].y = y0 - y;
+        }
+
+        nk_rawfb_fill_polygon(rawfb, pnts, 3, col);
+        pnts[2] = pnts[1];
+
+        if (sigma >= 0) {
+            sigma += fb2 * (1 - x);
+            x--;
+        }
+        sigma += a2 * ((4 * y) + 6);
+    }
+}
+
+static void
+nk_rawfb_stroke_rect(const struct rawfb_context *rawfb,
+                     const short x,
+                     const short y,
+                     const short w,
+                     const short h,
+                     const short r,
+                     const short line_thickness,
+                     const struct nk_color col)
+{
+    if (r == 0) {
+        nk_rawfb_stroke_line(rawfb, x, y, x + w, y, line_thickness, col);
+        nk_rawfb_stroke_line(rawfb, x, y + h, x + w, y + h, line_thickness, col);
+        nk_rawfb_stroke_line(rawfb, x, y, x, y + h, line_thickness, col);
+        nk_rawfb_stroke_line(rawfb, x + w, y, x + w, y + h, line_thickness, col);
+    } else {
+        const short xc = x + r;
+        const short yc = y + r;
+        const short wc = (short)(w - 2 * r);
+        const short hc = (short)(h - 2 * r);
+
+        nk_rawfb_stroke_line(rawfb, xc, y, xc + wc, y, line_thickness, col);
+        nk_rawfb_stroke_line(rawfb, x + w, yc, x + w, yc + hc, line_thickness, col);
+        nk_rawfb_stroke_line(rawfb, xc, y + h, xc + wc, y + h, line_thickness, col);
+        nk_rawfb_stroke_line(rawfb, x, yc, x, yc + hc, line_thickness, col);
+
+        nk_rawfb_stroke_arc(rawfb, xc + wc - r, y,
+                (unsigned)r*2, (unsigned)r*2, 0 , line_thickness, col);
+        nk_rawfb_stroke_arc(rawfb, x, y,
+                (unsigned)r*2, (unsigned)r*2, 90 , line_thickness, col);
+        nk_rawfb_stroke_arc(rawfb, x, yc + hc - r,
+                (unsigned)r*2, (unsigned)r*2, 270 , line_thickness, col);
+        nk_rawfb_stroke_arc(rawfb, xc + wc - r, yc + hc - r,
+                (unsigned)r*2, (unsigned)r*2, 180 , line_thickness, col);
+    }
+}
+
+static void
+nk_rawfb_fill_rect(const struct rawfb_context *rawfb,
+                   const short x,
+                   const short y,
+                   const short w,
+                   const short h,
+                   const short r,
+                   const struct nk_color col)
+{
+    if (r == 0) {
+        int i;
+        for (i = 0; i < h; i++) {
+            nk_rawfb_stroke_line(rawfb, x, y + i, x + w, y + i, 1, col);
+        }
+    } else {
+        const short xc = x + r;
+        const short yc = y + r;
+        const short wc = (short)(w - 2 * r);
+        const short hc = (short)(h - 2 * r);
+
+        struct nk_vec2i pnts[12];
+        pnts[0].x = x;
+        pnts[0].y = yc;
+        pnts[1].x = xc;
+        pnts[1].y = yc;
+        pnts[2].x = xc;
+        pnts[2].y = y;
+
+        pnts[3].x = xc + wc;
+        pnts[3].y = y;
+        pnts[4].x = xc + wc;
+        pnts[4].y = yc;
+        pnts[5].x = x + w;
+        pnts[5].y = yc;
+
+        pnts[6].x = x + w;
+        pnts[6].y = yc + hc;
+        pnts[7].x = xc + wc;
+        pnts[7].y = yc + hc;
+        pnts[8].x = xc + wc;
+        pnts[8].y = y + h;
+
+        pnts[9].x = xc;
+        pnts[9].y = y + h;
+        pnts[10].x = xc;
+        pnts[10].y = yc + hc;
+        pnts[11].x = x;
+        pnts[11].y = yc + hc;
+
+        nk_rawfb_fill_polygon(rawfb, pnts, 12, col);
+
+        nk_rawfb_fill_arc(rawfb, xc + wc - r, y,
+                (unsigned)r*2, (unsigned)r*2, 0 , col);
+        nk_rawfb_fill_arc(rawfb, x, y,
+                (unsigned)r*2, (unsigned)r*2, 90 , col);
+        nk_rawfb_fill_arc(rawfb, x, yc + hc - r,
+                (unsigned)r*2, (unsigned)r*2, 270 , col);
+        nk_rawfb_fill_arc(rawfb, xc + wc - r, yc + hc - r,
+                (unsigned)r*2, (unsigned)r*2, 180 , col);
+    }
+}
+
+static void
+nk_rawfb_fill_triangle(const struct rawfb_context *rawfb,
+                       const short x0,
+                       const short y0,
+                       const short x1,
+                       const short y1,
+                       const short x2,
+                       const short y2,
+                       const struct nk_color col)
+{
+    struct nk_vec2i pnts[3];
+
+    pnts[0].x = x0;
+    pnts[0].y = y0;
+    pnts[1].x = x1;
+    pnts[1].y = y1;
+    pnts[2].x = x2;
+    pnts[2].y = y2;
+
+    nk_rawfb_fill_polygon(rawfb, pnts, 3, col);
+}
+
+static void
+nk_rawfb_stroke_triangle(const struct rawfb_context *rawfb,
+                         const short x0,
+                         const short y0,
+                         const short x1,
+                         const short y1,
+                         const short x2,
+                         const short y2,
+                         const unsigned short line_thickness,
+                         const struct nk_color col)
+{
+    nk_rawfb_stroke_line(rawfb, x0, y0, x1, y1, line_thickness, col);
+    nk_rawfb_stroke_line(rawfb, x1, y1, x2, y2, line_thickness, col);
+    nk_rawfb_stroke_line(rawfb, x2, y2, x0, y0, line_thickness, col);
+}
+
+static void
+nk_rawfb_stroke_polygon(const struct rawfb_context *rawfb,
+                        const struct nk_vec2i *pnts,
+                        const int count,
+                        const unsigned short line_thickness,
+                        const struct nk_color col)
+{
+    int i;
+    for (i = 1; i < count; ++i)
+        nk_rawfb_stroke_line(rawfb, pnts[i-1].x, pnts[i-1].y, pnts[i].x,
+                pnts[i].y, line_thickness, col);
+
+    nk_rawfb_stroke_line(rawfb, pnts[count-1].x, pnts[count-1].y,
+            pnts[0].x, pnts[0].y, line_thickness, col);
+}
+
+static void
+nk_rawfb_stroke_polyline(const struct rawfb_context *rawfb,
+                         const struct nk_vec2i *pnts,
+                         const int count,
+                         const unsigned short line_thickness,
+                         const struct nk_color col)
+{
+    int i;
+    for (i = 0; i < count-1; ++i)
+        nk_rawfb_stroke_line(rawfb, pnts[i].x, pnts[i].y,
+                 pnts[i+1].x, pnts[i+1].y, line_thickness, col);
+}
+
+static void
+nk_rawfb_fill_circle(const struct rawfb_context *rawfb,
+                     short x0,
+                     short y0,
+                     short w,
+                     short h,
+                     const struct nk_color col)
+{
+    /* Bresenham's ellipses */
+    const int a2 = (w * w) / 4;
+    const int b2 = (h * h) / 4;
+    const int fa2 = 4 * a2, fb2 = 4 * b2;
+    int x, y, sigma;
+
+    /* Convert upper left to center */
+    h = (h + 1) / 2;
+    w = (w + 1) / 2;
+    x0 += w;
+    y0 += h;
+
+    /* First half */
+    for (x = 0, y = h, sigma = 2*b2+a2*(1-2*h); b2*x <= a2*y; x++) {
+        nk_rawfb_stroke_line(rawfb, x0 - x, y0 + y, x0 + x, y0 + y, 1, col);
+        nk_rawfb_stroke_line(rawfb, x0 - x, y0 - y, x0 + x, y0 - y, 1, col);
+        if (sigma >= 0) {
+            sigma += fa2 * (1 - y);
+            y--;
+        }
+        sigma += b2 * ((4 * x) + 6);
+    }
+
+    /* Second half */
+    for (x = w, y = 0, sigma = 2*a2+b2*(1-2*w); a2*y <= b2*x; y++) {
+        nk_rawfb_stroke_line(rawfb, x0 - x, y0 + y, x0 + x, y0 + y, 1, col);
+        nk_rawfb_stroke_line(rawfb, x0 - x, y0 - y, x0 + x, y0 - y, 1, col);
+        if (sigma >= 0) {
+            sigma += fb2 * (1 - x);
+            x--;
+        }
+        sigma += a2 * ((4 * y) + 6);
+    }
+}
+
+static void
+nk_rawfb_stroke_circle(const struct rawfb_context *rawfb,
+                       short x0,
+                       short y0,
+                       short w,
+                       short h,
+                       const short line_thickness,
+                       const struct nk_color col)
+{
+    /* Bresenham's ellipses */
+    const int a2 = (w * w) / 4;
+    const int b2 = (h * h) / 4;
+    const int fa2 = 4 * a2, fb2 = 4 * b2;
+    int x, y, sigma;
+
+    /* Convert upper left to center */
+    h = (h + 1) / 2;
+    w = (w + 1) / 2;
+    x0 += w;
+    y0 += h;
+
+    /* First half */
+    for (x = 0, y = h, sigma = 2*b2+a2*(1-2*h); b2*x <= a2*y; x++) {
+        nk_rawfb_setpixel(rawfb, x0 + x, y0 + y, col);
+        nk_rawfb_setpixel(rawfb, x0 - x, y0 + y, col);
+        nk_rawfb_setpixel(rawfb, x0 + x, y0 - y, col);
+        nk_rawfb_setpixel(rawfb, x0 - x, y0 - y, col);
+        if (sigma >= 0) {
+            sigma += fa2 * (1 - y);
+            y--;
+        }
+        sigma += b2 * ((4 * x) + 6);
+    }
+
+    /* Second half */
+    for (x = w, y = 0, sigma = 2*a2+b2*(1-2*w); a2*y <= b2*x; y++) {
+        nk_rawfb_setpixel(rawfb, x0 + x, y0 + y, col);
+        nk_rawfb_setpixel(rawfb, x0 - x, y0 + y, col);
+        nk_rawfb_setpixel(rawfb, x0 + x, y0 - y, col);
+        nk_rawfb_setpixel(rawfb, x0 - x, y0 - y, col);
+        if (sigma >= 0) {
+            sigma += fb2 * (1 - x);
+            x--;
+        }
+        sigma += a2 * ((4 * y) + 6);
+    }
+}
+
+static void
+nk_rawfb_stroke_curve(const struct rawfb_context *rawfb,
+                      const struct nk_vec2i p1,
+                      const struct nk_vec2i p2,
+                      const struct nk_vec2i p3,
+                      const struct nk_vec2i p4,
+                      const unsigned int num_segments,
+                      const unsigned short line_thickness,
+                      const struct nk_color col)
+{
+    unsigned int i_step, segments;
+    float t_step;
+    struct nk_vec2i last = p1;
+
+    segments = MAX(num_segments, 1);
+    t_step = 1.0f/(float)segments;
+    for (i_step = 1; i_step <= segments; ++i_step) {
+        float t = t_step * (float)i_step;
+        float u = 1.0f - t;
+        float w1 = u*u*u;
+        float w2 = 3*u*u*t;
+        float w3 = 3*u*t*t;
+        float w4 = t * t *t;
+        float x = w1 * p1.x + w2 * p2.x + w3 * p3.x + w4 * p4.x;
+        float y = w1 * p1.y + w2 * p2.y + w3 * p3.y + w4 * p4.y;
+        nk_rawfb_stroke_line(rawfb, last.x, last.y,
+                (short)x, (short)y, line_thickness,col);
+        last.x = (short)x; last.y = (short)y;
+    }
+}
+
+static void
+nk_rawfb_clear(const struct rawfb_context *rawfb,
+               const struct nk_color col)
+{
+    nk_rawfb_fill_rect(rawfb, 0, 0, rawfb->fb.w, rawfb->fb.h, 0, col);
+}
+
+NK_API struct rawfb_context*
+nk_rawfb_init(void *fb,
+              void *tex_mem,
+              const unsigned int w,
+              const unsigned int h,
+              const unsigned int pitch)
+{
+    const void *tex;
+    struct rawfb_context *rawfb;
+
+    rawfb = malloc(sizeof(struct rawfb_context));
+    if (!rawfb)
+        return NULL;
+
+    nk_memset(rawfb, 0, sizeof(struct rawfb_context));
+
+    rawfb->font_tex.pixels = tex_mem;
+    rawfb->font_tex.format = NK_FONT_ATLAS_ALPHA8;
+    rawfb->font_tex.w = 0;
+    rawfb->font_tex.h = 0;
+
+    rawfb->fb.pixels = fb;
+    rawfb->fb.w= w;
+    rawfb->fb.h = h;
+
+#if defined(RAWFB_XRGB_8888) || defined(RAWFB_RGBX_8888)
+        rawfb->fb.format = NK_FONT_ATLAS_RGBA32;
+        rawfb->fb.pitch = pitch;
+#else
+#error Fixme
+#endif
+
+    nk_init_default(&rawfb->ctx, 0);
+
+    nk_font_atlas_init_default(&rawfb->atlas);
+    nk_font_atlas_begin(&rawfb->atlas);
+
+    tex = nk_font_atlas_bake(&rawfb->atlas, &rawfb->font_tex.w, &rawfb->font_tex.h, rawfb->font_tex.format);
+    if (!tex)
+        return 0;
+
+    switch(rawfb->font_tex.format) {
+    case NK_FONT_ATLAS_ALPHA8:
+        rawfb->font_tex.pitch = rawfb->font_tex.w * 1;
+        break;
+    case NK_FONT_ATLAS_RGBA32:
+        rawfb->font_tex.pitch = rawfb->font_tex.w * 4;
+        break;
+    };
+
+    /* Store the font texture in tex scratch memory */
+    memcpy(rawfb->font_tex.pixels, tex, rawfb->font_tex.pitch * rawfb->font_tex.h);
+
+    nk_font_atlas_end(&rawfb->atlas, nk_handle_ptr(NULL), NULL);
+
+    if (rawfb->atlas.default_font)
+        nk_style_set_font(&rawfb->ctx, &rawfb->atlas.default_font->handle);
+
+    nk_style_load_all_cursors(&rawfb->ctx, rawfb->atlas.cursors);
+
+    nk_rawfb_scissor(rawfb, 0, 0, rawfb->fb.w, rawfb->fb.h);
+
+    return rawfb;
+}
+
+static void
+nk_rawfb_stretch_image(const struct rawfb_image *dst,
+                       const struct rawfb_image *src,
+                       const struct nk_rect *dst_rect,
+                       const struct nk_rect *src_rect,
+                       const struct nk_rect *dst_scissors)
+{
+    struct nk_color col;
+    short i, j;
+
+    float xinc = src_rect->w / dst_rect->w;
+    float yinc = src_rect->h / dst_rect->h;
+
+    float xoff = src_rect->x, yoff = src_rect->y;
+
+    /* Simple nearest filtering rescaling */
+    /* TODO: use bilinear filter */
+    for (j = 0; j < (short)dst_rect->h; j++) {
+        for (i = 0; i < (short)dst_rect->w; i++) {
+            if (dst_scissors) {
+                if (i + (int)(dst_rect->x + 0.5f) < dst_scissors->x || i + (int)(dst_rect->x + 0.5f) >= dst_scissors->w)
+                    continue;
+                if (j + (int)(dst_rect->y + 0.5f) < dst_scissors->y || j + (int)(dst_rect->y + 0.5f) >= dst_scissors->h)
+                    continue;
+            }
+            col = nk_image_getpixel(src, (int)xoff, (int) yoff);
+            nk_image_blendpixel(dst, i + (int)(dst_rect->x + 0.5f), j + (int)(dst_rect->y + 0.5f), col);
+            xoff += xinc;
+        }
+        xoff = src_rect->x;
+        yoff += yinc;
+    }
+}
+
+static void
+nk_rawfb_font_query_font_glyph(nk_handle handle,
+                               const float height,
+                               struct nk_user_font_glyph *glyph,
+                               const nk_rune codepoint,
+                               const nk_rune next_codepoint)
+{
+    float scale;
+    const struct nk_font_glyph *g;
+    struct nk_font *font;
+
+    NK_ASSERT(glyph);
+    NK_UNUSED(next_codepoint);
+
+    font = (struct nk_font*)handle.ptr;
+    NK_ASSERT(font);
+    NK_ASSERT(font->glyphs);
+    if (!font || !glyph)
+        return;
+
+    scale = height/font->info.height;
+    g = nk_font_find_glyph(font, codepoint);
+    glyph->width = (g->x1 - g->x0) * scale;
+    glyph->height = (g->y1 - g->y0) * scale;
+    glyph->offset = nk_vec2(g->x0 * scale, g->y0 * scale);
+    glyph->xadvance = (g->xadvance * scale);
+    glyph->uv[0] = nk_vec2(g->u0, g->v0);
+    glyph->uv[1] = nk_vec2(g->u1, g->v1);
+}
+
+NK_API void
+nk_rawfb_draw_text(const struct rawfb_context *rawfb,
+                   const struct nk_user_font *font,
+                   const struct nk_rect rect,
+                   const char *text,
+                   const int len,
+                   const float font_height,
+                   const struct nk_color fg)
+{
+    float x = 0;
+    int text_len = 0;
+    nk_rune unicode = 0;
+    nk_rune next = 0;
+    int glyph_len = 0;
+    int next_glyph_len = 0;
+    struct nk_user_font_glyph g;
+
+    if (!len || !text) return;
+
+    x = 0;
+    glyph_len = nk_utf_decode(text, &unicode, len);
+    if (!glyph_len) return;
+
+    /* draw every glyph image */
+    while (text_len < len && glyph_len) {
+        struct nk_rect src_rect;
+        struct nk_rect dst_rect;
+        float char_width = 0;
+        if (unicode == NK_UTF_INVALID) break;
+
+        /* query currently drawn glyph information */
+        next_glyph_len = nk_utf_decode(text + text_len + glyph_len, &next, (int)len - text_len);
+        nk_rawfb_font_query_font_glyph(font->userdata, font_height, &g, unicode,
+                    (next == NK_UTF_INVALID) ? '\0' : next);
+
+        /* calculate and draw glyph drawing rectangle and image */
+        char_width = g.xadvance;
+
+        src_rect.x = g.uv[0].x * rawfb->font_tex.w;
+        src_rect.y = g.uv[0].y * rawfb->font_tex.h;
+        src_rect.w = g.uv[1].x * rawfb->font_tex.w - g.uv[0].x * rawfb->font_tex.w;
+        src_rect.h = g.uv[1].y * rawfb->font_tex.h - g.uv[0].y * rawfb->font_tex.h;
+
+        dst_rect.x = x + g.offset.x + rect.x;
+        dst_rect.y = g.offset.y + rect.y;
+        dst_rect.w = ceilf(g.width);
+        dst_rect.h = ceilf(g.height);
+
+        /* TODO: account fg */
+
+        /* Use software rescaling to blit glyph from font_text to framebuffer */
+        nk_rawfb_stretch_image(&rawfb->fb, &rawfb->font_tex, &dst_rect, &src_rect, &rawfb->scissors);
+
+        /* offset next glyph */
+        text_len += glyph_len;
+        x += char_width;
+        glyph_len = next_glyph_len;
+        unicode = next;
+    }
+}
+
+NK_API void
+nk_rawfb_drawimage(const struct rawfb_context *rawfb,
+                   const int x,
+                   const int y,
+                   const int w,
+                   const int h,
+                   const struct nk_image *img,
+                   const struct nk_color *col)
+{
+    struct nk_rect src_rect;
+    struct nk_rect dst_rect;
+
+    src_rect.x = img->region[0];
+    src_rect.y = img->region[1];
+    src_rect.w = img->region[2];
+    src_rect.h = img->region[3];
+
+    dst_rect.x = x;
+    dst_rect.y = y;
+    dst_rect.w = w;
+    dst_rect.h = h;
+
+    nk_rawfb_stretch_image(&rawfb->fb, &rawfb->font_tex, &dst_rect, &src_rect, &rawfb->scissors);
+}
+
+NK_API void
+nk_rawfb_shutdown(struct rawfb_context *rawfb)
+{
+    nk_free(&rawfb->ctx);
+    nk_memset(rawfb, 0, sizeof(struct rawfb_context));
+    free(rawfb);
+}
+
+NK_API void
+nk_rawfb_resize_fb(struct rawfb_context *rawfb,
+                   void *fb,
+                   const unsigned int w,
+                   const unsigned int h,
+                   const unsigned int pitch)
+{
+    rawfb->fb.w = w;
+    rawfb->fb.h = h;
+    rawfb->fb.pixels = fb;
+    rawfb->fb.pitch = pitch;
+}
+
+NK_API void
+nk_rawfb_render(const struct rawfb_context *rawfb,
+                const struct nk_color clear,
+                const unsigned char enable_clear)
+{
+    const struct nk_command *cmd;
+
+    if (enable_clear)
+        nk_rawfb_clear(rawfb, clear);
+
+    nk_foreach(cmd, (struct nk_context*)&rawfb->ctx) {
+        switch (cmd->type) {
+        case NK_COMMAND_NOP: break;
+        case NK_COMMAND_SCISSOR: {
+            const struct nk_command_scissor *s =(const struct nk_command_scissor*)cmd;
+            nk_rawfb_scissor((struct rawfb_context *)rawfb, s->x, s->y, s->w, s->h);
+        } break;
+        case NK_COMMAND_LINE: {
+            const struct nk_command_line *l = (const struct nk_command_line *)cmd;
+            nk_rawfb_stroke_line(rawfb, l->begin.x, l->begin.y, l->end.x,
+                l->end.y, l->line_thickness, l->color);
+        } break;
+        case NK_COMMAND_RECT: {
+            const struct nk_command_rect *r = (const struct nk_command_rect *)cmd;
+            nk_rawfb_stroke_rect(rawfb, r->x, r->y, r->w, r->h,
+                (unsigned short)r->rounding, r->line_thickness, r->color);
+        } break;
+        case NK_COMMAND_RECT_FILLED: {
+            const struct nk_command_rect_filled *r = (const struct nk_command_rect_filled *)cmd;
+            nk_rawfb_fill_rect(rawfb, r->x, r->y, r->w, r->h,
+                (unsigned short)r->rounding, r->color);
+        } break;
+        case NK_COMMAND_CIRCLE: {
+            const struct nk_command_circle *c = (const struct nk_command_circle *)cmd;
+            nk_rawfb_stroke_circle(rawfb, c->x, c->y, c->w, c->h, c->line_thickness, c->color);
+        } break;
+        case NK_COMMAND_CIRCLE_FILLED: {
+            const struct nk_command_circle_filled *c = (const struct nk_command_circle_filled *)cmd;
+            nk_rawfb_fill_circle(rawfb, c->x, c->y, c->w, c->h, c->color);
+        } break;
+        case NK_COMMAND_TRIANGLE: {
+            const struct nk_command_triangle*t = (const struct nk_command_triangle*)cmd;
+            nk_rawfb_stroke_triangle(rawfb, t->a.x, t->a.y, t->b.x, t->b.y,
+                t->c.x, t->c.y, t->line_thickness, t->color);
+        } break;
+        case NK_COMMAND_TRIANGLE_FILLED: {
+            const struct nk_command_triangle_filled *t = (const struct nk_command_triangle_filled *)cmd;
+            nk_rawfb_fill_triangle(rawfb, t->a.x, t->a.y, t->b.x, t->b.y,
+                t->c.x, t->c.y, t->color);
+        } break;
+        case NK_COMMAND_POLYGON: {
+            const struct nk_command_polygon *p =(const struct nk_command_polygon*)cmd;
+            nk_rawfb_stroke_polygon(rawfb, p->points, p->point_count, p->line_thickness,p->color);
+        } break;
+        case NK_COMMAND_POLYGON_FILLED: {
+            const struct nk_command_polygon_filled *p = (const struct nk_command_polygon_filled *)cmd;
+            nk_rawfb_fill_polygon(rawfb, p->points, p->point_count, p->color);
+        } break;
+        case NK_COMMAND_POLYLINE: {
+            const struct nk_command_polyline *p = (const struct nk_command_polyline *)cmd;
+            nk_rawfb_stroke_polyline(rawfb, p->points, p->point_count, p->line_thickness, p->color);
+        } break;
+        case NK_COMMAND_TEXT: {
+            const struct nk_command_text *t = (const struct nk_command_text*)cmd;
+            nk_rawfb_draw_text(rawfb, t->font, nk_rect(t->x, t->y, t->w, t->h),
+                t->string, t->length, t->height, t->foreground);
+        } break;
+        case NK_COMMAND_CURVE: {
+            const struct nk_command_curve *q = (const struct nk_command_curve *)cmd;
+            nk_rawfb_stroke_curve(rawfb, q->begin, q->ctrl[0], q->ctrl[1],
+                q->end, 22, q->line_thickness, q->color);
+        } break;
+        case NK_COMMAND_RECT_MULTI_COLOR:
+        case NK_COMMAND_IMAGE: {
+            const struct nk_command_image *q = (const struct nk_command_image *)cmd;
+            nk_rawfb_drawimage(rawfb, q->x, q->y, q->w, q->h, &q->img, &q->col);
+        } break;
+        case NK_COMMAND_ARC: {
+            assert(0 && "NK_COMMAND_ARC not implemented\n");
+        } break;
+        case NK_COMMAND_ARC_FILLED: {
+            assert(0 && "NK_COMMAND_ARC_FILLED not implemented\n");
+        } break;
+        default: break;
+        }
+    }
+    nk_clear((struct nk_context*)&rawfb->ctx);
+}
+#endif

--- a/demo/x11_rawfb/nuklear_xlib.h
+++ b/demo/x11_rawfb/nuklear_xlib.h
@@ -1,0 +1,298 @@
+/*
+ * Nuklear - v1.17 - public domain
+ * no warrenty implied; use at your own risk.
+ * authored from 2015-2016 by Micha Mettke
+ * Copyright 2016 Patrick Rudolph
+ */
+/*
+ * ==============================================================
+ *
+ *                              API
+ *
+ * ===============================================================
+ */
+#ifndef NK_XLIBSHM_H_
+#define NK_XLIBSHM_H_
+
+#include <X11/Xlib.h>
+
+NK_API int  nk_xlib_init(Display *dpy, Visual *vis, int screen, Window root, unsigned int w, unsigned int h, void **fb);
+NK_API int  nk_xlib_handle_event(Display *dpy, int screen, Window win, XEvent *evt, struct rawfb_context *rawfb);
+NK_API void nk_xlib_render(Drawable screen);
+NK_API void nk_xlib_shutdown(void);
+
+#endif
+/*
+ * ==============================================================
+ *
+ *                          IMPLEMENTATION
+ *
+ * ===============================================================
+ */
+#ifdef NK_XLIBSHM_IMPLEMENTATION
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <X11/Xresource.h>
+#include <X11/Xlocale.h>
+#include <X11/extensions/XShm.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
+
+static struct  {
+    struct nk_context ctx;
+    struct XSurface *surf;
+    Cursor cursor;
+    Display *dpy;
+    Window root;
+    XImage *ximg;
+    XShmSegmentInfo xsi;
+    char fallback;
+    GC gc;
+} xlib;
+
+NK_API int
+nk_xlib_init(Display *dpy, Visual *vis, int screen, Window root,
+    unsigned int w, unsigned int h, void **fb)
+{
+    unsigned int depth = XDefaultDepth(dpy, screen);
+    xlib.dpy = dpy;
+    xlib.root = root;
+
+    if (!setlocale(LC_ALL,"")) return 0;
+    if (!XSupportsLocale()) return 0;
+    if (!XSetLocaleModifiers("@im=none")) return 0;
+
+    /* create invisible cursor */
+    {static XColor dummy; char data[1] = {0};
+    Pixmap blank = XCreateBitmapFromData(dpy, root, data, 1, 1);
+    if (blank == None) return 0;
+    xlib.cursor = XCreatePixmapCursor(dpy, blank, blank, &dummy, &dummy, 0, 0);
+    XFreePixmap(dpy, blank);}
+
+    xlib.fallback = False;
+    do
+    {
+        int status;
+
+        /* Initialize shared memory according to:
+         * https://www.x.org/archive/X11R7.5/doc/Xext/mit-shm.html */
+
+        if (!XShmQueryExtension(dpy))
+        {
+            printf("No XShm Extension available.\n");
+            xlib.fallback = True;
+            break;
+        }
+
+        xlib.ximg = XShmCreateImage(dpy, vis, depth, ZPixmap, NULL, &xlib.xsi, w, h);
+        if (!xlib.ximg)
+        {
+            xlib.fallback = True;
+            break;
+        }
+
+        xlib.xsi.shmid = shmget(IPC_PRIVATE, xlib.ximg->bytes_per_line * xlib.ximg->height, IPC_CREAT | 0777);
+        if (xlib.xsi.shmid < 0)
+        {
+            XDestroyImage(xlib.ximg);
+            xlib.fallback = True;
+            break;
+        }
+
+        xlib.xsi.shmaddr = xlib.ximg->data = shmat(xlib.xsi.shmid, NULL, 0);
+        if ((size_t)xlib.xsi.shmaddr < 0)
+        {
+            XDestroyImage(xlib.ximg);
+            xlib.fallback = True;
+            break;
+        }
+
+        xlib.xsi.readOnly = False;
+        status = XShmAttach(dpy, &xlib.xsi);
+        if (!status)
+        {
+            shmdt(xlib.xsi.shmaddr);
+            XDestroyImage(xlib.ximg);
+            xlib.fallback = True;
+            break;
+        }
+
+        XSync(dpy, False);
+
+        shmctl(xlib.xsi.shmid, IPC_RMID, NULL);
+    } while(0);
+
+    if (xlib.fallback)
+    {
+        xlib.ximg = XCreateImage(dpy, vis, depth, ZPixmap, 0, NULL, w, h, 32, 0);
+        if (!xlib.ximg)
+            return 0;
+
+        xlib.ximg->data = malloc(h * xlib.ximg->bytes_per_line);
+        if (!xlib.ximg->data)
+            return 0;
+    }
+
+    xlib.gc = XDefaultGC(dpy, screen);
+
+    *fb = xlib.ximg->data;
+
+    return 1;
+}
+
+NK_API int
+nk_xlib_handle_event(Display *dpy, int screen, Window win, XEvent *evt, struct rawfb_context *rawfb)
+{
+    /* optional grabbing behavior */
+    if (rawfb->ctx.input.mouse.grab) {
+        /* XDefineCursor(xlib.dpy, xlib.root, xlib.cursor); */
+        rawfb->ctx.input.mouse.grab = 0;
+    } else if (rawfb->ctx.input.mouse.ungrab) {
+        XWarpPointer(xlib.dpy, None, xlib.root, 0, 0, 0, 0,
+            (int)rawfb->ctx.input.mouse.prev.x, (int)rawfb->ctx.input.mouse.prev.y);
+        /* XUndefineCursor(xlib.dpy, xlib.root); */
+        rawfb->ctx.input.mouse.ungrab = 0;
+    }
+
+    if (evt->type == KeyPress || evt->type == KeyRelease)
+    {
+        /* Key handler */
+        int ret, down = (evt->type == KeyPress);
+        KeySym *code = XGetKeyboardMapping(xlib.dpy, (KeyCode)evt->xkey.keycode, 1, &ret);
+        if (*code == XK_Shift_L || *code == XK_Shift_R) nk_input_key(&rawfb->ctx, NK_KEY_SHIFT, down);
+        else if (*code == XK_Delete)    nk_input_key(&rawfb->ctx, NK_KEY_DEL, down);
+        else if (*code == XK_Return)    nk_input_key(&rawfb->ctx, NK_KEY_ENTER, down);
+        else if (*code == XK_Tab)       nk_input_key(&rawfb->ctx, NK_KEY_TAB, down);
+        else if (*code == XK_Left)      nk_input_key(&rawfb->ctx, NK_KEY_LEFT, down);
+        else if (*code == XK_Right)     nk_input_key(&rawfb->ctx, NK_KEY_RIGHT, down);
+        else if (*code == XK_Up)        nk_input_key(&rawfb->ctx, NK_KEY_UP, down);
+        else if (*code == XK_Down)      nk_input_key(&rawfb->ctx, NK_KEY_DOWN, down);
+        else if (*code == XK_BackSpace) nk_input_key(&rawfb->ctx, NK_KEY_BACKSPACE, down);
+        else if (*code == XK_Escape)    nk_input_key(&rawfb->ctx, NK_KEY_TEXT_RESET_MODE, down);
+        else if (*code == XK_Page_Up)   nk_input_key(&rawfb->ctx, NK_KEY_SCROLL_UP, down);
+        else if (*code == XK_Page_Down) nk_input_key(&rawfb->ctx, NK_KEY_SCROLL_DOWN, down);
+        else if (*code == XK_Home) {
+            nk_input_key(&rawfb->ctx, NK_KEY_TEXT_START, down);
+            nk_input_key(&rawfb->ctx, NK_KEY_SCROLL_START, down);
+        } else if (*code == XK_End) {
+            nk_input_key(&rawfb->ctx, NK_KEY_TEXT_END, down);
+            nk_input_key(&rawfb->ctx, NK_KEY_SCROLL_END, down);
+        } else {
+            if (*code == 'c' && (evt->xkey.state & ControlMask))
+                nk_input_key(&rawfb->ctx, NK_KEY_COPY, down);
+            else if (*code == 'v' && (evt->xkey.state & ControlMask))
+                nk_input_key(&rawfb->ctx, NK_KEY_PASTE, down);
+            else if (*code == 'x' && (evt->xkey.state & ControlMask))
+                nk_input_key(&rawfb->ctx, NK_KEY_CUT, down);
+            else if (*code == 'z' && (evt->xkey.state & ControlMask))
+                nk_input_key(&rawfb->ctx, NK_KEY_TEXT_UNDO, down);
+            else if (*code == 'r' && (evt->xkey.state & ControlMask))
+                nk_input_key(&rawfb->ctx, NK_KEY_TEXT_REDO, down);
+            else if (*code == XK_Left && (evt->xkey.state & ControlMask))
+                nk_input_key(&rawfb->ctx, NK_KEY_TEXT_WORD_LEFT, down);
+            else if (*code == XK_Right && (evt->xkey.state & ControlMask))
+                nk_input_key(&rawfb->ctx, NK_KEY_TEXT_WORD_RIGHT, down);
+            else if (*code == 'b' && (evt->xkey.state & ControlMask))
+                nk_input_key(&rawfb->ctx, NK_KEY_TEXT_LINE_START, down);
+            else if (*code == 'e' && (evt->xkey.state & ControlMask))
+                nk_input_key(&rawfb->ctx, NK_KEY_TEXT_LINE_END, down);
+            else {
+                if (*code == 'i')
+                    nk_input_key(&rawfb->ctx, NK_KEY_TEXT_INSERT_MODE, down);
+                else if (*code == 'r')
+                    nk_input_key(&rawfb->ctx, NK_KEY_TEXT_REPLACE_MODE, down);
+                if (down) {
+                    char buf[32];
+                    KeySym keysym = 0;
+                    if (XLookupString((XKeyEvent*)evt, buf, 32, &keysym, NULL) != NoSymbol)
+                        nk_input_glyph(&rawfb->ctx, buf);
+                }
+            }
+        }
+        XFree(code);
+        return 1;
+    } else if (evt->type == ButtonPress || evt->type == ButtonRelease) {
+        /* Button handler */
+        int down = (evt->type == ButtonPress);
+        const int x = evt->xbutton.x, y = evt->xbutton.y;
+        if (evt->xbutton.button == Button1)
+            nk_input_button(&rawfb->ctx, NK_BUTTON_LEFT, x, y, down);
+        if (evt->xbutton.button == Button2)
+            nk_input_button(&rawfb->ctx, NK_BUTTON_MIDDLE, x, y, down);
+        else if (evt->xbutton.button == Button3)
+            nk_input_button(&rawfb->ctx, NK_BUTTON_RIGHT, x, y, down);
+        else if (evt->xbutton.button == Button4)
+            nk_input_scroll(&rawfb->ctx, nk_vec2(0, 1.0f));
+        else if (evt->xbutton.button == Button5)
+            nk_input_scroll(&rawfb->ctx, nk_vec2(0, -1.0f));
+        else return 0;
+        return 1;
+    } else if (evt->type == MotionNotify) {
+        /* Mouse motion handler */
+        const int x = evt->xmotion.x, y = evt->xmotion.y;
+        nk_input_motion(&rawfb->ctx, x, y);
+        if (rawfb->ctx.input.mouse.grabbed) {
+            rawfb->ctx.input.mouse.pos.x = rawfb->ctx.input.mouse.prev.x;
+            rawfb->ctx.input.mouse.pos.y = rawfb->ctx.input.mouse.prev.y;
+            XWarpPointer(xlib.dpy, None, xlib.root, 0, 0, 0, 0, (int)rawfb->ctx.input.mouse.pos.x, (int)rawfb->ctx.input.mouse.pos.y);
+        }
+        return 1;
+    } else if (evt->type == Expose || evt->type == ConfigureNotify) {
+        /* Window resize handler */
+        XWindowAttributes attr;
+        XGetWindowAttributes(dpy, win, &attr);
+        unsigned int width, height;
+        void *fb;
+
+        width = (unsigned int)attr.width;
+        height = (unsigned int)attr.height;
+
+        nk_xlib_shutdown();
+
+        nk_xlib_init(dpy, XDefaultVisual(dpy, screen), screen, win,
+                 width, height, &fb);
+
+        nk_rawfb_resize_fb(rawfb, fb, width, height, width * 4);
+
+    } else if (evt->type == KeymapNotify) {
+        XRefreshKeyboardMapping(&evt->xmapping);
+        return 1;
+    } else if (evt->type == LeaveNotify) {
+        XUndefineCursor(xlib.dpy, xlib.root);
+    } else if (evt->type == EnterNotify) {
+        XDefineCursor(xlib.dpy, xlib.root, xlib.cursor);
+    }
+
+    return 0;
+}
+
+NK_API void
+nk_xlib_shutdown(void)
+{
+    XFreeCursor(xlib.dpy, xlib.cursor);
+    if (xlib.fallback)
+    {
+        free(xlib.ximg->data);
+        XDestroyImage(xlib.ximg);
+    }
+    else
+    {
+        XShmDetach(xlib.dpy, &xlib.xsi);
+        XDestroyImage(xlib.ximg);
+        shmdt(xlib.xsi.shmaddr);
+        shmctl(xlib.xsi.shmid, IPC_RMID, NULL);
+    }
+    nk_memset(&xlib, 0, sizeof(xlib));
+}
+
+NK_API void
+nk_xlib_render(Drawable screen)
+{
+    if (xlib.fallback)
+        XPutImage(xlib.dpy, screen, xlib.gc, xlib.ximg,
+            0, 0, 0, 0, xlib.ximg->width, xlib.ximg->height);
+    else
+        XShmPutImage(xlib.dpy, screen, xlib.gc, xlib.ximg,
+            0, 0, 0, 0, xlib.ximg->width, xlib.ximg->height, False);
+}
+#endif

--- a/nuklear.h
+++ b/nuklear.h
@@ -2320,7 +2320,7 @@ typedef void(*nk_query_font_glyph_f)(nk_handle handle, float font_height,
                                     struct nk_user_font_glyph *glyph,
                                     nk_rune codepoint, nk_rune next_codepoint);
 
-#ifdef NK_INCLUDE_VERTEX_BUFFER_OUTPUT
+#if defined(NK_INCLUDE_VERTEX_BUFFER_OUTPUT) || defined(NK_INCLUDE_SOFTWARE_FONT)
 struct nk_user_font_glyph {
     struct nk_vec2 uv[2];
     /* texture coordinates */


### PR DESCRIPTION
Add software rasterizer library and demo.
The software rasterizer is to be used with raw framebuffer
devices, where no GPU or X11 is available.
The demo emulates a raw framebuffer on X11 using XShmImage / XImage.
Fonts are rendered software only using nearest filtering.

Tested:
The library has been tested on Lenovo Thinkpad T500 and is able to render more than 30fps on a single core with no further optimizations and VSNYC enabled.

TODO:
Improve font rendering by using filters.
Window resizing isn't supported by the X11 demo application.

Signed-off-by: Patrick Rudolph <siro@das-labor.org>