### PR TITLE
Implemented nk_create_image and nk_delete_image for the win32 gdi

### DIFF
--- a/demo/gdi/nuklear_gdi.h
+++ b/demo/gdi/nuklear_gdi.h
@@ -57,6 +57,78 @@ static struct {
     struct nk_context ctx;
 } gdi;
 
+static void
+nk_create_image(struct nk_image * image, const char * frame_buffer, const int width, const int height)
+{
+    if (image && frame_buffer && (width > 0) && (height > 0))
+    {
+        image->w = width;
+        image->h = height;
+        image->region[0] = 0;
+        image->region[1] = 0;
+        image->region[2] = width;
+        image->region[3] = height;
+        
+        INT row = ((width * 3 + 3) & ~3);
+        BITMAPINFO bi = { 0 };
+        bi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+        bi.bmiHeader.biWidth = width;
+        bi.bmiHeader.biHeight = height;
+        bi.bmiHeader.biPlanes = 1;
+        bi.bmiHeader.biBitCount = 24;
+        bi.bmiHeader.biCompression = BI_RGB;
+        bi.bmiHeader.biSizeImage = row * height;
+        
+        LPBYTE lpBuf, pb = NULL;
+        HBITMAP hbm = CreateDIBSection(NULL, &bi, DIB_RGB_COLORS, (void**)&lpBuf, NULL, 0);
+        
+        pb = lpBuf + row * height;
+        unsigned char * src = (unsigned char *)frame_buffer;
+        for (int v = 0; v<height; v++)
+        {
+            pb -= row;
+            for (int i = 0; i < row; i += 3)
+            {
+                pb[i + 0] = src[0];
+                pb[i + 1] = src[1];
+                pb[i + 2] = src[2];
+                src += 3;
+            }
+        }        
+        SetDIBits(NULL, hbm, 0, height, lpBuf, &bi, DIB_RGB_COLORS);
+        image->handle.ptr = hbm;
+    }
+}
+
+static void
+nk_delete_image(struct nk_image * image)
+{
+    if (image && image->handle.id != 0)
+    {
+        HBITMAP hbm = image->handle.ptr;
+        DeleteObject(hbm);
+        memset(image, 0, sizeof(struct nk_image));
+    }
+}
+
+static void
+nk_gdi_draw_image(short x, short y, unsigned short w, unsigned short h,
+	struct nk_image img, struct nk_color col)
+{
+    HBITMAP	hbm = img.handle.ptr;
+    HDC     hDCBits;
+    BITMAP  bitmap;
+    
+    if (!gdi.memory_dc || !hbm)
+        return;
+    
+    hDCBits = CreateCompatibleDC(gdi.memory_dc);
+    GetObject(hbm, sizeof(BITMAP), (LPSTR)&bitmap);
+    SelectObject(hDCBits, hbm);
+    StretchBlt(gdi.memory_dc, x, y, w, h, hDCBits, 0, 0, bitmap.bmWidth, bitmap.bmHeight, SRCCOPY);
+    DeleteDC(hDCBits);
+}
+
 static COLORREF
 convert_color(struct nk_color c)
 {
@@ -752,7 +824,10 @@ nk_gdi_render(struct nk_color clear)
                 q->end, q->line_thickness, q->color);
         } break;
         case NK_COMMAND_RECT_MULTI_COLOR:
-        case NK_COMMAND_IMAGE:
+        case NK_COMMAND_IMAGE: {
+			const struct nk_command_image *i = (const struct nk_command_image *)cmd;
+			nk_gdi_draw_image(i->x, i->y, i->w, i->h, i->img, i->col);
+		} break;
         case NK_COMMAND_ARC:
         case NK_COMMAND_ARC_FILLED:
         default: break;


### PR DESCRIPTION
Implemented nk_create_image and nk_delete_image.
the image is simple raw buffers in 24 bits (no alpha), in my case they are buffers received over the network.
This patch allows to create an interface using nk_images and nuklear controls together...