### PR TITLE
fix: warning unused variable in nk_layout_reset_min_row_height()

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -19079,7 +19079,6 @@ nk_layout_reset_min_row_height(struct nk_context *ctx)
 {
     struct nk_window *win;
     struct nk_panel *layout;
-    struct nk_font *font;
 
     NK_ASSERT(ctx);
     NK_ASSERT(ctx->current);


### PR DESCRIPTION
Hello.

> In revision 4741669, gcc 2.7.2 generates a warning in the function nk_layout_reset_min_row_height():
> warning: unused variable `font'

I fixed it. Thanks.
