### PR TITLE
Fix GLFW double clicking

### DIFF
--- a/demo/glfw_opengl3/nuklear_glfw_gl3.h
+++ b/demo/glfw_opengl3/nuklear_glfw_gl3.h
@@ -87,6 +87,8 @@ static struct nk_glfw {
     int text_len;
     struct nk_vec2 scroll;
     double last_button_click;
+    int is_double_click_down;
+    struct nk_vec2 double_click_pos;
 } glfw;
 
 #ifdef __APPLE__
@@ -328,10 +330,12 @@ nk_glfw3_mouse_button_callback(GLFWwindow* window, int button, int action, int m
     glfwGetCursorPos(window, &x, &y);
     if (action == GLFW_PRESS)  {
         double dt = glfwGetTime() - glfw.last_button_click;
-        if (dt > NK_GLFW_DOUBLE_CLICK_LO && dt < NK_GLFW_DOUBLE_CLICK_HI)
-            nk_input_button(&glfw.ctx, NK_BUTTON_DOUBLE, (int)x, (int)y, nk_true);
+        if (dt > NK_GLFW_DOUBLE_CLICK_LO && dt < NK_GLFW_DOUBLE_CLICK_HI) {
+            glfw.is_double_click_down = nk_true;
+            glfw.double_click_pos = nk_vec2(x, y);
+        }
         glfw.last_button_click = glfwGetTime();
-    } else nk_input_button(&glfw.ctx, NK_BUTTON_DOUBLE, (int)x, (int)y, nk_false);
+    } else glfw.is_double_click_down = nk_false;
 }
 
 NK_INTERN void
@@ -371,6 +375,10 @@ nk_glfw3_init(GLFWwindow *win, enum nk_glfw_init_state init_state)
     glfw.ctx.clip.userdata = nk_handle_ptr(0);
     glfw.last_button_click = 0;
     nk_glfw3_device_create();
+
+    glfw.is_double_click_down = nk_false;
+    glfw.double_click_pos = nk_vec2(0, 0);
+
     return &glfw.ctx;
 }
 
@@ -465,6 +473,7 @@ nk_glfw3_new_frame(void)
     nk_input_button(ctx, NK_BUTTON_LEFT, (int)x, (int)y, glfwGetMouseButton(win, GLFW_MOUSE_BUTTON_LEFT) == GLFW_PRESS);
     nk_input_button(ctx, NK_BUTTON_MIDDLE, (int)x, (int)y, glfwGetMouseButton(win, GLFW_MOUSE_BUTTON_MIDDLE) == GLFW_PRESS);
     nk_input_button(ctx, NK_BUTTON_RIGHT, (int)x, (int)y, glfwGetMouseButton(win, GLFW_MOUSE_BUTTON_RIGHT) == GLFW_PRESS);
+    nk_input_button(ctx, NK_BUTTON_DOUBLE, glfw.double_click_pos.x, glfw.double_click_pos.y, glfw.is_double_click_down);
     nk_input_scroll(ctx, glfw.scroll);
     nk_input_end(&glfw.ctx);
     glfw.text_len = 0;


### PR DESCRIPTION
In the GLFW demos, the NK_BUTTON_DOUBLE mouse button's clicked property is never true. I believe this is caused by nk_input_button() being called inside a callback. On the Windows and Linux machines I tested it on, the callback is called right before nk_input_begin(), which was clearing the button's state. I changed it to set a variable which is passed to Nuklear along with all of the other mouse buttons, after nk_input_begin() has been called.

Thanks for all your work, Nuklear is a great library!