### PR TITLE
Fix typos in comments

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -1,6 +1,6 @@
 /*
  Nuklear - 1.40.0 - public domain
- no warrenty implied; use at your own risk.
+ no warranty implied; use at your own risk.
  authored from 2015-2017 by Micha Mettke
 
 ABOUT:
@@ -47,7 +47,7 @@ USAGE:
                 or even worse stack corruptions.
 
 FEATURES:
-    - Absolutely no platform dependend code
+    - Absolutely no platform dependent code
     - Memory management control ranging from/to
         - Ease of use by allocating everything from standard library
         - Control every byte of memory inside the library
@@ -128,7 +128,7 @@ OPTIONAL DEFINES:
         <!> If used needs to be defined for implementation and header <!>
 
     NK_BUTTON_TRIGGER_ON_RELEASE
-        Different platforms require button clicks occuring either on buttons being
+        Different platforms require button clicks occurring either on buttons being
         pressed (up to down) or released (down to up).
         By default this library will react on buttons being pressed, but if you
         define this it will only trigger if a button is released.
@@ -516,7 +516,7 @@ enum nk_symbol_type {
  *  To use a context it first has to be initialized which can be achieved by calling
  *  one of either `nk_init_default`, `nk_init_fixed`, `nk_init`, `nk_init_custom`.
  *  Each takes in a font handle and a specific way of handling memory. Memory control
- *  hereby ranges from standard library to just specifing a fixed sized block of memory
+ *  hereby ranges from standard library to just specifying a fixed sized block of memory
  *  which nuklear has to manage itself from.
  *
  *      struct nk_context ctx;
@@ -529,7 +529,7 @@ enum nk_symbol_type {
  *
  *  Reference
  *  -------------------
- *  nk_init_default     - Initializes context with standard library memory alloction (malloc,free)
+ *  nk_init_default     - Initializes context with standard library memory allocation (malloc,free)
  *  nk_init_fixed       - Initializes context from single fixed size memory block
  *  nk_init             - Initializes context with memory allocator callbacks for alloc and free
  *  nk_init_custom      - Initializes context from two buffers. One for draw commands the other for window/panel/table allocations
@@ -549,10 +549,10 @@ enum nk_symbol_type {
 NK_API int nk_init_default(struct nk_context*, const struct nk_user_font*);
 #endif
 /*  nk_init_fixed - Initializes a `nk_context` struct from a single fixed size memory block
- *  Should be used if you want complete control over nuklears memory management.
+ *  Should be used if you want complete control over nuklear's memory management.
  *  Especially recommended for system with little memory or systems with virtual memory.
  *  For the later case you can just allocate for example 16MB of virtual memory
- *  and only the required amount of memory will actually be commited.
+ *  and only the required amount of memory will actually be committed.
  *  IMPORTANT: make sure the passed memory block is aligned correctly for `nk_draw_commands`
  *  Parameters:
  *      @ctx must point to an either stack or heap allocated `nk_context` struct
@@ -700,28 +700,28 @@ enum nk_buttons {
     NK_BUTTON_MAX
 };
 /*  nk_input_begin - Begins the input mirroring process by resetting text, scroll
- *  mouse previous mouse position and movement as well as key state transistions,
+ *  mouse previous mouse position and movement as well as key state transitions,
  *  Parameters:
  *      @ctx must point to an previously initialized `nk_context` struct */
 NK_API void nk_input_begin(struct nk_context*);
-/*  nk_input_motion - Mirros current mouse position to nuklear
+/*  nk_input_motion - Mirrors current mouse position to nuklear
  *  Parameters:
  *      @ctx must point to an previously initialized `nk_context` struct
- *      @x must constain an integer describing the current mouse cursor x-position
- *      @y must constain an integer describing the current mouse cursor y-position */
+ *      @x must contain an integer describing the current mouse cursor x-position
+ *      @y must contain an integer describing the current mouse cursor y-position */
 NK_API void nk_input_motion(struct nk_context*, int x, int y);
-/*  nk_input_key - Mirros state of a specific key to nuklear
+/*  nk_input_key - Mirrors state of a specific key to nuklear
  *  Parameters:
  *      @ctx must point to an previously initialized `nk_context` struct
  *      @key must be any value specified in enum `nk_keys` that needs to be mirrored
  *      @down must be 0 for key is up and 1 for key is down */
 NK_API void nk_input_key(struct nk_context*, enum nk_keys, int down);
-/*  nk_input_button - Mirros the state of a specific mouse button to nuklear
+/*  nk_input_button - Mirrors the state of a specific mouse button to nuklear
  *  Parameters:
  *      @ctx must point to an previously initialized `nk_context` struct
  *      @nk_buttons must be any value specified in enum `nk_buttons` that needs to be mirrored
- *      @x must constain an integer describing mouse cursor x-position on click up/down
- *      @y must constain an integer describing mouse cursor y-position on click up/down
+ *      @x must contain an integer describing mouse cursor x-position on click up/down
+ *      @y must contain an integer describing mouse cursor y-position on click up/down
  *      @down must be 0 for key is up and 1 for key is down */
 NK_API void nk_input_button(struct nk_context*, enum nk_buttons, int x, int y, int down);
 /*  nk_input_char - Copies a single ASCII character into an internal text buffer
@@ -746,7 +746,7 @@ NK_API void nk_input_char(struct nk_context*, char);
  *  struct `nk_input` between `nk_input_begin` and `nk_input_end`.
  *  Parameters:
  *      @ctx must point to an previously initialized `nk_context` struct
- *      @glyph UTF-32 uncode codepoint */
+ *      @glyph UTF-32 unicode codepoint */
 NK_API void nk_input_glyph(struct nk_context*, const nk_glyph);
 /*  nk_input_unicode - Converts a unicode rune into UTF-8 and copies the result
  *  into an internal text buffer.
@@ -754,7 +754,7 @@ NK_API void nk_input_glyph(struct nk_context*, const nk_glyph);
  *  struct `nk_input` between `nk_input_begin` and `nk_input_end`.
  *  Parameters:
  *      @ctx must point to an previously initialized `nk_context` struct
- *      @glyph UTF-32 uncode codepoint */
+ *      @glyph UTF-32 unicode codepoint */
 NK_API void nk_input_unicode(struct nk_context*, nk_rune);
 /*  nk_input_end - End the input mirroring process by resetting mouse grabbing
  *  state to ensure the mouse cursor is not grabbed indefinitely.
@@ -872,7 +872,7 @@ NK_API void nk_input_end(struct nk_context*);
  *      nk_free(&ctx);
  *
  *  The second probably more applicable trick is to only draw if anything changed.
- *  It is not really useful for applications with continous draw loop but
+ *  It is not really useful for applications with continuous draw loop but
  *  quite useful for desktop applications. To actually get nuklear to only
  *  draw on changes you first have to define `NK_ZERO_COMMAND_MEMORY` and
  *  allocate a memory buffer that will store each unique drawing output.
@@ -920,7 +920,7 @@ NK_API void nk_input_end(struct nk_context*);
  *  hardware directly. Therefore it is possible to just define
  *  `NK_INCLUDE_VERTEX_BUFFER_OUTPUT` which includes optional vertex output.
  *  To access the vertex output you first have to convert all draw commands into
- *  vertexes by calling `nk_convert` which takes in your prefered vertex format.
+ *  vertexes by calling `nk_convert` which takes in your preferred vertex format.
  *  After successfully converting all draw commands just iterate over and execute all
  *  vertex draw commands:
  *
@@ -959,9 +959,9 @@ NK_API void nk_input_end(struct nk_context*);
  *  -------------------
  *  nk__begin           - Returns the first draw command in the context draw command list to be drawn
  *  nk__next            - Increments the draw command iterator to the next command inside the context draw command list
- *  nk_foreach          - Iteratates over each draw command inside the context draw command list
+ *  nk_foreach          - Iterates over each draw command inside the context draw command list
  *
- *  nk_convert          - Converts from the abstract draw commands list into a hardware accessable vertex format
+ *  nk_convert          - Converts from the abstract draw commands list into a hardware accessible vertex format
  *  nk__draw_begin      - Returns the first vertex command in the context vertex draw list to be executed
  *  nk__draw_next       - Increments the vertex command iterator to the next command inside the context vertex command list
  *  nk__draw_end        - Returns the end of the vertex draw list
@@ -989,7 +989,7 @@ struct nk_convert_config {
     struct nk_draw_null_texture null; /* handle to texture with a white pixel for shape drawing */
     const struct nk_draw_vertex_layout_element *vertex_layout; /* describes the vertex output format and packing */
     nk_size vertex_size; /* sizeof one vertex for vertex packing */
-    nk_size vertex_alignment; /* vertex alignment: Can be optained by NK_ALIGNOF */
+    nk_size vertex_alignment; /* vertex alignment: Can be obtained by NK_ALIGNOF */
 };
 /*  nk__begin - Returns a draw command list iterator to iterate all draw
  *  commands accumulated over one frame.
@@ -1012,14 +1012,14 @@ NK_API const struct nk_command* nk__next(struct nk_context*, const struct nk_com
 #define nk_foreach(c, ctx) for((c) = nk__begin(ctx); (c) != 0; (c) = nk__next(ctx,c))
 #ifdef NK_INCLUDE_VERTEX_BUFFER_OUTPUT
 /*  nk_convert - converts all internal draw command into vertex draw commands and fills
- *  three buffers with vertexes, vertex draw commands and vertex indicies. The vertex format
- *  as well as some other configuration values have to be configurated by filling out a
+ *  three buffers with vertexes, vertex draw commands and vertex indices. The vertex format
+ *  as well as some other configuration values have to be configured by filling out a
  *  `nk_convert_config` struct.
  *  Parameters:
  *      @ctx must point to an previously initialized `nk_context` struct at the end of a frame
  *      @cmds must point to a previously initialized buffer to hold converted vertex draw commands
- *      @vertices must point to a previously initialized buffer to hold all produced verticies
- *      @elements must point to a previously initialized buffer to hold all procudes vertex indicies
+ *      @vertices must point to a previously initialized buffer to hold all produced vertices
+ *      @elements must point to a previously initialized buffer to hold all produced vertex indices
  *      @config must point to a filled out `nk_config` struct to configure the conversion process
  *  Returns:
  *      returns NK_CONVERT_SUCCESS on success and a enum nk_convert_result error values if not */
@@ -1038,7 +1038,7 @@ NK_API const struct nk_draw_command* nk__draw_begin(const struct nk_context*, co
  *  Return values:
  *      vertex draw command pointer pointing to the end of the last vertex draw command inside the vertex draw command buffer  */
 NK_API const struct nk_draw_command* nk__draw_end(const struct nk_context*, const struct nk_buffer*);
-/*  nk__draw_next - Increments the the vertex draw command buffer iterator
+/*  nk__draw_next - Increments the vertex draw command buffer iterator
  *  Parameters:
  *      @cmd must point to an previously either by `nk__draw_begin` or `nk__draw_next` returned vertex draw command
  *      @buf must point to an previously by `nk_convert` filled out vertex draw command buffer
@@ -1070,7 +1070,7 @@ NK_API const struct nk_draw_command* nk__draw_next(const struct nk_draw_command*
  * order. The topmost window thereby is the currently active window.
  *
  * To change window position inside the stack occurs either automatically by
- * user input by being clicked on or programatically by calling `nk_window_focus`.
+ * user input by being clicked on or programmatically by calling `nk_window_focus`.
  * Windows by default are visible unless explicitly being defined with flag
  * `NK_WINDOW_HIDDEN`, the user clicked the close button on windows with flag
  * `NK_WINDOW_CLOSABLE` or if a window was explicitly hidden by calling
@@ -1082,9 +1082,9 @@ NK_API const struct nk_draw_command* nk__draw_next(const struct nk_draw_command*
  * functions to start window declarations and `nk_end` at the end. Furthermore it
  * is recommended to check the return value of `nk_begin_xxx` and only process
  * widgets inside the window if the value is not 0. Either way you have to call
- * `nk_end` at the end of window declarations. Furthmore do not attempt to
+ * `nk_end` at the end of window declarations. Furthermore, do not attempt to
  * nest `nk_begin_xxx` calls which will hopefully result in an assert or if not
- * in a segmation fault.
+ * in a segmentation fault.
  *
  *      if (nk_begin_xxx(...) {
  *          [... widgets ...]
@@ -1094,7 +1094,7 @@ NK_API const struct nk_draw_command* nk__draw_next(const struct nk_draw_command*
  * In the grand concept window and widget declarations need to occur after input
  * handling and before drawing to screen. Not doing so can result in higher
  * latency or at worst invalid behavior. Furthermore make sure that `nk_clear`
- * is called at the end of the frame. While nuklears default platform backends
+ * is called at the end of the frame. While nuklear's default platform backends
  * already call `nk_clear` for you if you write your own backend not calling
  * `nk_clear` can cause asserts or even worse undefined behavior.
  *
@@ -1135,7 +1135,7 @@ NK_API const struct nk_draw_command* nk__draw_next(const struct nk_draw_command*
  *  Reference
  *  -------------------
  *  nk_begin                            - starts a new window; needs to be called every frame for every window (unless hidden) or otherwise the window gets removed
- *  nk_begin_titled                     - extended window start with seperated title and identifier to allow multiple windows with same name but not title
+ *  nk_begin_titled                     - extended window start with separated title and identifier to allow multiple windows with same name but not title
  *  nk_end                              - needs to be called at the end of the window building process to process scaling, scrollbars and general cleanup
  *
  *  nk_window_find                      - finds and returns the window with give name
@@ -1144,7 +1144,7 @@ NK_API const struct nk_draw_command* nk__draw_next(const struct nk_draw_command*
  *  nk_window_get_size                  - returns the size with width and height of the currently processed window
  *  nk_window_get_width                 - returns the width of the currently processed window
  *  nk_window_get_height                - returns the height of the currently processed window
- *  nk_window_get_panel                 - returns the underlying panel which contains all processing state of the currnet window
+ *  nk_window_get_panel                 - returns the underlying panel which contains all processing state of the current window
  *  nk_window_get_content_region        - returns the position and size of the currently visible and non-clipped space inside the currently processed window
  *  nk_window_get_content_region_min    - returns the upper rectangle position of the currently visible and non-clipped space inside the currently processed window
  *  nk_window_get_content_region_max    - returns the upper rectangle position of the currently visible and non-clipped space inside the currently processed window
@@ -1157,7 +1157,7 @@ NK_API const struct nk_draw_command* nk__draw_next(const struct nk_draw_command*
  *  nk_window_is_hidden                 - returns if the currently processed window was hidden
  *  nk_window_is_active                 - same as nk_window_has_focus for some reason
  *  nk_window_is_hovered                - returns if the currently processed window is currently being hovered by mouse
- *  nk_window_is_any_hovered            - return if any wndow currently hovered
+ *  nk_window_is_any_hovered            - return if any window currently hovered
  *  nk_item_is_any_active               - returns if any window or widgets is currently hovered or active
  *
  *  nk_window_set_bounds                - updates position and size of the currently processed window
@@ -1187,16 +1187,16 @@ enum nk_panel_flags {
 /*  nk_begin - starts a new window; needs to be called every frame for every window (unless hidden) or otherwise the window gets removed
  *  Parameters:
  *      @ctx must point to an previously initialized `nk_context` struct
- *      @title window title and identifier. Needs to be persitent over frames to identify the window
+ *      @title window title and identifier. Needs to be persistent over frames to identify the window
  *      @bounds initial position and window size. However if you do not define `NK_WINDOW_SCALABLE` or `NK_WINDOW_MOVABLE` you can set window position and size every frame
  *      @flags window flags defined in `enum nk_panel_flags` with a number of different window behaviors
  *  Return values:
  *      returns 1 if the window can be filled up with widgets from this point until `nk_end or 0 otherwise for example if minimized `*/
 NK_API int nk_begin(struct nk_context *ctx, const char *title, struct nk_rect bounds, nk_flags flags);
-/*  nk_begin_titled - extended window start with seperated title and identifier to allow multiple windows with same name but not title
+/*  nk_begin_titled - extended window start with separated title and identifier to allow multiple windows with same name but not title
  *  Parameters:
  *      @ctx must point to an previously initialized `nk_context` struct
- *      @name window identifier. Needs to be persitent over frames to identify the window
+ *      @name window identifier. Needs to be persistent over frames to identify the window
  *      @title window title displayed inside header if flag `NK_WINDOW_TITLE` or either `NK_WINDOW_CLOSABLE` or `NK_WINDOW_MINIMIZED` was set
  *      @bounds initial position and window size. However if you do not define `NK_WINDOW_SCALABLE` or `NK_WINDOW_MOVABLE` you can set window position and size every frame
  *      @flags window flags defined in `enum nk_panel_flags` with a number of different window behaviors
@@ -1213,7 +1213,7 @@ NK_API void nk_end(struct nk_context *ctx);
  *      @ctx must point to an previously initialized `nk_context` struct
  *      @name window identifier
  *  Return values:
- *      returns a `nk_window` struct pointing to the idified window or 0 if no window with given name was found */
+ *      returns a `nk_window` struct pointing to the identified window or 0 if no window with given name was found */
 NK_API struct nk_window *nk_window_find(struct nk_context *ctx, const char *name);
 /*  nk_window_get_bounds - returns a rectangle with screen position and size of the currently processed window.
  *  IMPORTANT: only call this function between calls `nk_begin_xxx` and `nk_end`
@@ -1250,7 +1250,7 @@ NK_API float nk_window_get_width(const struct nk_context*);
  *  Return values:
  *      returns the window height */
 NK_API float nk_window_get_height(const struct nk_context*);
-/*  nk_window_get_panel - returns the underlying panel which contains all processing state of the currnet window.
+/*  nk_window_get_panel - returns the underlying panel which contains all processing state of the current window.
  *  IMPORTANT: only call this function between calls `nk_begin_xxx` and `nk_end`
  *  Parameters:
  *      @ctx must point to an previously initialized `nk_context` struct
@@ -1386,7 +1386,7 @@ NK_API void nk_window_collapse(struct nk_context*, const char *name, enum nk_col
  *      @ctx must point to an previously initialized `nk_context` struct
  *      @name of the window to be either collapse or maximize
  *      @state the window should be put into
- *      @condition that has to be true to actually commit the collsage state change */
+ *      @condition that has to be true to actually commit the collapse state change */
 NK_API void nk_window_collapse_if(struct nk_context*, const char *name, enum nk_collapse_states, int cond);
 /*  nk_window_show - updates visibility state of a window with given name
  *  Parameters:
@@ -1410,14 +1410,14 @@ NK_API void nk_window_show_if(struct nk_context*, const char *name, enum nk_show
  *  While in this particular implementation there are five different APIs for layouting
  *  each with different trade offs between control and ease of use.
  *
- *  All layouting methodes in this library are based around the concept of a row.
+ *  All layouting methods in this library are based around the concept of a row.
  *  A row has a height the window content grows by and a number of columns and each
  *  layouting method specifies how each widget is placed inside the row.
  *  After a row has been allocated by calling a layouting functions and then
  *  filled with widgets will advance an internal pointer over the allocated row.
  *
- *  To acually define a layout you just call the appropriate layouting function
- *  and each subsequnetial widget call will place the widget as specified. Important
+ *  To actually define a layout you just call the appropriate layouting function
+ *  and each subsequent widget call will place the widget as specified. Important
  *  here is that if you define more widgets then columns defined inside the layout
  *  functions it will allocate the next row without you having to make another layouting
  *  call.
@@ -1576,8 +1576,8 @@ NK_API void nk_window_show_if(struct nk_context*, const char *name, enum nk_show
  *  one is the static widget size specifier with fixed widget pixel width. They do
  *  not grow if the row grows and will always stay the same. The second size
  *  specifier is nk_layout_row_template_push_variable which defines a
- *  minumum widget size but it also can grow if more space is available not taken
- *  by other widgets. Finally there are dynamic widgets which are completly flexible
+ *  minimum widget size but it also can grow if more space is available not taken
+ *  by other widgets. Finally there are dynamic widgets which are completely flexible
  *  and unlike variable widgets can even shrink to zero if not enough space
  *  is provided.
  *
@@ -1604,9 +1604,9 @@ NK_API void nk_window_show_if(struct nk_context*, const char *name, enum nk_show
  *  Finally the most flexible API directly allows you to place widgets inside the
  *  window. The space layout API is an immediate mode API which does not support
  *  row auto repeat and directly sets position and size of a widget. Position
- *  and size hereby can be either specified as ratio of alloated space or
+ *  and size hereby can be either specified as ratio of allocated space or
  *  allocated space local position and pixel size. Since this API is quite
- *  powerfull there are a number of utility functions to get the available space
+ *  powerful there are a number of utility functions to get the available space
  *  and convert between local allocated space and screen space.
  *
  *      if (nk_begin_xxx(...) {
@@ -1635,7 +1635,7 @@ NK_API void nk_window_show_if(struct nk_context*, const char *name, enum nk_show
  *  nk_layout_widget_bounds                 - calculates current width a static layout row can fit inside a window
  *  nk_layout_ratio_from_pixel              - utility functions to calculate window ratio from pixel size
  *
- *  nk_layout_row_dynamic                   - current layout is divided into n same sized gowing columns
+ *  nk_layout_row_dynamic                   - current layout is divided into n same sized growing columns
  *  nk_layout_row_static                    - current layout is divided into n same fixed sized columns
  *  nk_layout_row_begin                     - starts a new row with given height and number of columns
  *  nk_layout_row_push                      - pushes another column with given size or window ratio
@@ -1649,17 +1649,17 @@ NK_API void nk_window_show_if(struct nk_context*, const char *name, enum nk_show
  *  nk_layout_row_template_end              - marks the end of the row template
  *
  *  nk_layout_space_begin                   - begins a new layouting space that allows to specify each widgets position and size
- *  nk_layout_space_push                    - pushes position and size of the next widget in own coordiante space either as pixel or ratio
+ *  nk_layout_space_push                    - pushes position and size of the next widget in own coordinate space either as pixel or ratio
  *  nk_layout_space_end                     - marks the end of the layouting space
  *
  *  nk_layout_space_bounds                  - callable after nk_layout_space_begin and returns total space allocated
- *  nk_layout_space_to_screen               - convertes vector from nk_layout_space coordiant space into screen space
- *  nk_layout_space_to_local                - convertes vector from screem space into nk_layout_space coordinates
- *  nk_layout_space_rect_to_screen          - convertes rectangle from nk_layout_space coordiant space into screen space
- *  nk_layout_space_rect_to_local           - convertes rectangle from screem space into nk_layout_space coordinates
+ *  nk_layout_space_to_screen               - converts vector from nk_layout_space coordinate space into screen space
+ *  nk_layout_space_to_local                - converts vector from screen space into nk_layout_space coordinates
+ *  nk_layout_space_rect_to_screen          - converts rectangle from nk_layout_space coordinate space into screen space
+ *  nk_layout_space_rect_to_local           - converts rectangle from screen space into nk_layout_space coordinates
  */
 /*  nk_layout_set_min_row_height - sets the currently used minimum row height.
- *  IMPORTANT: The passed height needs to include both your prefered row height
+ *  IMPORTANT: The passed height needs to include both your preferred row height
  *  as well as padding. No internal padding is added.
  *  Parameters:
  *      @ctx must point to an previously initialized `nk_context` struct after call `nk_begin_xxx`
@@ -1736,7 +1736,7 @@ NK_API void nk_layout_row_template_push_variable(struct nk_context*, float min_w
 /*  nk_layout_row_template_push_static - adds a static column that does not grow and will always have the same size
  *  Parameters:
  *      @ctx must point to an previously initialized `nk_context` struct after call `nk_layout_row_template_begin`
- *      @width holds the absolulte pixel width value the next column must be */
+ *      @width holds the absolute pixel width value the next column must be */
 NK_API void nk_layout_row_template_push_static(struct nk_context*, float width);
 /*  nk_layout_row_template_end - marks the end of the row template
  *  Parameters:
@@ -1749,7 +1749,7 @@ NK_API void nk_layout_row_template_end(struct nk_context*);
  *      @row_height holds height of each widget in row or zero for auto layouting
  *      @widget_count number of widgets inside row */
 NK_API void nk_layout_space_begin(struct nk_context*, enum nk_layout_format, float height, int widget_count);
-/*  nk_layout_space_push - pushes position and size of the next widget in own coordiante space either as pixel or ratio
+/*  nk_layout_space_push - pushes position and size of the next widget in own coordinate space either as pixel or ratio
  *  Parameters:
  *      @ctx must point to an previously initialized `nk_context` struct after call `nk_layout_space_begin`
  *      @bounds position and size in laoyut space local coordinates */
@@ -1762,22 +1762,22 @@ NK_API void nk_layout_space_end(struct nk_context*);
  *  Parameters:
  *      @ctx must point to an previously initialized `nk_context` struct after call `nk_layout_space_begin` */
 NK_API struct nk_rect nk_layout_space_bounds(struct nk_context*);
-/*  nk_layout_space_to_screen - convertes vector from nk_layout_space coordiant space into screen space
+/*  nk_layout_space_to_screen - converts vector from nk_layout_space coordinate space into screen space
  *  Parameters:
  *      @ctx must point to an previously initialized `nk_context` struct after call `nk_layout_space_begin`
  *      @vec position to convert from layout space into screen coordinate space */
 NK_API struct nk_vec2 nk_layout_space_to_screen(struct nk_context*, struct nk_vec2);
-/*  nk_layout_space_to_screen - convertes vector from layout space into screen space
+/*  nk_layout_space_to_screen - converts vector from layout space into screen space
  *  Parameters:
  *      @ctx must point to an previously initialized `nk_context` struct after call `nk_layout_space_begin`
  *      @vec position to convert from screen space into layout coordinate space */
 NK_API struct nk_vec2 nk_layout_space_to_local(struct nk_context*, struct nk_vec2);
-/*  nk_layout_space_rect_to_screen - convertes rectangle from screen space into layout space
+/*  nk_layout_space_rect_to_screen - converts rectangle from screen space into layout space
  *  Parameters:
  *      @ctx must point to an previously initialized `nk_context` struct after call `nk_layout_space_begin`
  *      @bounds rectangle to convert from layout space into screen space */
 NK_API struct nk_rect nk_layout_space_rect_to_screen(struct nk_context*, struct nk_rect);
-/*  nk_layout_space_rect_to_local - convertes rectangle from layout space into screen space
+/*  nk_layout_space_rect_to_local - converts rectangle from layout space into screen space
  *  Parameters:
  *      @ctx must point to an previously initialized `nk_context` struct after call `nk_layout_space_begin`
  *      @bounds rectangle to convert from screen space into layout space */
@@ -2321,7 +2321,7 @@ NK_API const char* nk_utf_at(const char *buffer, int length, int index, nk_rune 
     different ways to use the font atlas. The first two will use your font
     handling scheme and only requires essential data to run nuklear. The next
     slightly more advanced features is font handling with vertex buffer output.
-    Finally the most complex API wise is using nuklears font baking API.
+    Finally the most complex API wise is using nuklear's font baking API.
 
     1.) Using your own implementation without vertex buffer output
     --------------------------------------------------------------
@@ -2394,7 +2394,7 @@ NK_API const char* nk_utf_at(const char *buffer, int length, int index, nk_rune 
     ------------------------------------
     The final approach if you do not have a font handling functionality or don't
     want to use it in this library is by using the optional font baker.
-    The font baker API's can be used to create a font plus font atlas texture
+    The font baker APIs can be used to create a font plus font atlas texture
     and can be used with or without the vertex buffer output.
 
     It still uses the `nk_user_font` struct and the two different approaches
@@ -2409,7 +2409,7 @@ NK_API const char* nk_utf_at(const char *buffer, int length, int index, nk_rune 
     memory is temporary and therefore can be freed directly after the baking process
     is over or permanent you can call `nk_font_atlas_init`.
 
-    After successfull intializing the font baker you can add Truetype(.ttf) fonts from
+    After successfully initializing the font baker you can add Truetype(.ttf) fonts from
     different sources like memory or from file by calling one of the `nk_font_atlas_add_xxx`.
     functions. Adding font will permanently store each font, font config and ttf memory block(!)
     inside the font atlas and allows to reuse the font atlas. If you don't want to reuse
@@ -2417,7 +2417,7 @@ NK_API const char* nk_utf_at(const char *buffer, int length, int index, nk_rune 
     `nk_font_atlas_cleanup` after the baking process is over (after calling nk_font_atlas_end).
 
     As soon as you added all fonts you wanted you can now start the baking process
-    for every selected glyphes to image by calling `nk_font_atlas_bake`.
+    for every selected glyph to image by calling `nk_font_atlas_bake`.
     The baking process returns image memory, width and height which can be used to
     either create your own image object or upload it to any graphics library.
     No matter which case you finally have to call `nk_font_atlas_end` which
@@ -2451,7 +2451,7 @@ NK_API const char* nk_utf_at(const char *buffer, int length, int index, nk_rune 
     I would suggest reading some of my examples `example/` to get a grip on how
     to use the font atlas. There are a number of details I left out. For example
     how to merge fonts, configure a font with `nk_font_config` to use other languages,
-    use another texture coodinate format and a lot more:
+    use another texture coordinate format and a lot more:
 
         struct nk_font_config cfg = nk_font_config(font_pixel_height);
         cfg.merge_mode = nk_false or nk_true;
@@ -2786,7 +2786,7 @@ NK_API int nk_str_len_char(struct nk_str*);
  * First of is the most basic way of just providing a simple char array with
  * string length. This method is probably the easiest way of handling simple
  * user text input. Main upside is complete control over memory while the biggest
- * downside in comparsion with the other two approaches is missing undo/redo.
+ * downside in comparison with the other two approaches is missing undo/redo.
  *
  * For UIs that require undo/redo the second way was created. It is based on
  * a fixed size nk_text_edit struct, which has an internal undo/redo stack.
@@ -2933,8 +2933,8 @@ NK_API void nk_textedit_redo(struct nk_text_edit*);
     but also returns the state of the widget space. If your widget is not seen and does
     not have to be updated it is '0' and you can just return. If it only has
     to be drawn the state will be `NK_WIDGET_ROM` otherwise you can do both
-    update and draw your widget. The reason for seperating is to only draw and
-    update what is actually neccessary which is crucial for performance.
+    update and draw your widget. The reason for separating is to only draw and
+    update what is actually necessary which is crucial for performance.
 */
 enum nk_command_type {
     NK_COMMAND_NOP,
@@ -4371,7 +4371,7 @@ NK_GLOBAL const struct nk_color nk_yellow = {255,255,0,255};
     ----
     For square root nuklear uses the famous fast inverse square root:
     https://en.wikipedia.org/wiki/Fast_inverse_square_root with
-    slightly tweaked magic constant. While on todays hardware it is
+    slightly tweaked magic constant. While on today's hardware it is
     probably not faster it is still fast and accurate enough for
     nuklear's use cases. IMPORTANT: this requires float format IEEE 754
 
@@ -4382,7 +4382,7 @@ NK_GLOBAL const struct nk_color nk_yellow = {255,255,0,255};
     approximate exactly that range is that nuklear only needs sine and
     cosine to generate circles which only requires that exact range.
     In addition I used Remez instead of Taylor for additional precision:
-    www.lolengine.net/blog/2011/12/21/better-function-approximatations.
+    www.lolengine.net/blog/2011/12/21/better-function-approximations.
 
     The tool I used to generate constants for both sine and cosine
     (it can actually approximate a lot more functions) can be
@@ -4889,7 +4889,7 @@ nk_strmatch_fuzzy_text(const char *str, int str_len,
     const char *pattern, int *out_score)
 {
     /* Returns true if each character in pattern is found sequentially within str
-     * if found then outScore is also set. Score value has no intrinsic meaning.
+     * if found then out_score is also set. Score value has no intrinsic meaning.
      * Range varies with pattern. Can only compare scores with same search pattern. */
 
     /* ------- scores --------- */
@@ -15373,7 +15373,7 @@ nk_edit_draw_text(struct nk_command_buffer *out,
     while ((text_len < byte_len) && glyph_len)
     {
         if (unicode == '\n') {
-            /* new line sepeator so draw previous line */
+            /* new line separator so draw previous line */
             struct nk_rect label;
             label.y = pos_y + line_offset;
             label.h = row_height;


### PR DESCRIPTION
This commit fixes all the typos I could find in the comments by running them through a spellchecker.