### PR TITLE
Fix comment for closing #endif

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -4243,7 +4243,7 @@ template<typename T> struct nk_alignof{struct Big {T x; char c;}; enum {
 #define NK_ALIGNOF(t) ((char*)(&((struct {char c; t _h;}*)0)->_h) - (char*)0)
 #endif
 
-#endif /* NK_H_ */
+#endif /* NK_NUKLEAR_H_ */
 /*
  * ==============================================================
  *


### PR DESCRIPTION
I believe it should be `NK_NUKLEAR_H_` instead of `NK_H_`.