### PR TITLE
Add comment to closing #endif statement

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -23653,4 +23653,4 @@ NK_API void
 nk_menu_end(struct nk_context *ctx)
 {nk_contextual_end(ctx);}
 
-#endif
+#endif /* NK_IMPLEMENTATION */


### PR DESCRIPTION
I think this adds more clarity to the library. I.e. that it is organized into 2 large `#define` statements. The first large statement (`NK_NUKLEAR_H_`) has a comment for it's closing `#endif` statement. The second one (`NK_IMPLEMENTATION`) does not.