### PR TITLE
missing parameter to nk_window_set_bounds call

### DIFF
--- a/example/canvas.c
+++ b/example/canvas.c
@@ -371,7 +371,7 @@ canvas_begin(struct nk_context *ctx, struct nk_canvas *canvas, nk_flags flags,
     /* create/update window and set position + size */
     flags = flags & ~NK_WINDOW_DYNAMIC;
     nk_begin(ctx, "Window", nk_rect(x, y, width, height), NK_WINDOW_NO_SCROLLBAR|flags);
-    nk_window_set_bounds(ctx, nk_rect(x, y, width, height));
+    nk_window_set_bounds(ctx, "Window", nk_rect(x, y, width, height));
 
     /* allocate the complete window space for drawing */
     {struct nk_rect total_space;


### PR DESCRIPTION
`nk_window_set_bounds` function expects 3 parameters, the 2nd of which is the window `name`