### PR TITLE
GDI+ nk_gdip_fill_rect background fix

### DIFF
--- a/demo/gdip/nuklear_gdip.h
+++ b/demo/gdip/nuklear_gdip.h
@@ -458,8 +458,9 @@ nk_gdip_fill_rect(short x, short y, unsigned short w,
         GdipFillRectangleI(gdip.memory, gdip.brush, x, y, w, h);
     } else {
         INT d = 2 * r;
-        GdipFillRectangleI(gdip.memory, gdip.brush, x + r - 1, y, w - d + 2, h);
-        GdipFillRectangleI(gdip.memory, gdip.brush, x, y + r - 1, w, h - d + 2);
+        GdipFillRectangleI(gdip.memory, gdip.brush, x + r, y, w - d, h);
+        GdipFillRectangleI(gdip.memory, gdip.brush, x, y + r, r, h - d);
+        GdipFillRectangleI(gdip.memory, gdip.brush, x + w - r, y + r, r, h - d);
         GdipFillPieI(gdip.memory, gdip.brush, x, y, d, d, 180, 90);
         GdipFillPieI(gdip.memory, gdip.brush, x + w - d, y, d, d, 270, 90);
         GdipFillPieI(gdip.memory, gdip.brush, x + w - d, y + h - d, d, d, 0, 90);

--- a/demo/x11/nuklear_xlib.h
+++ b/demo/x11/nuklear_xlib.h
@@ -389,12 +389,8 @@ nk_xsurf_draw_text(XSurface *surf, short x, short y, unsigned short w, unsigned 
     const char *text, int len, XFont *font, struct nk_color cbg, struct nk_color cfg)
 {
     int tx, ty;
-    unsigned long bg = nk_color_from_byte(&cbg.r);
     unsigned long fg = nk_color_from_byte(&cfg.r);
-
-    XSetForeground(surf->dpy, surf->gc, bg);
-    XFillRectangle(surf->dpy, surf->drawable, surf->gc, (int)x, (int)y, (unsigned)w, (unsigned)h);
-    if(!text || !font || !len) return;
+    (void)cbg;
 
     tx = (int)x;
     ty = (int)y + font->ascent;

--- a/demo/x11/nuklear_xlib.h
+++ b/demo/x11/nuklear_xlib.h
@@ -389,8 +389,12 @@ nk_xsurf_draw_text(XSurface *surf, short x, short y, unsigned short w, unsigned 
     const char *text, int len, XFont *font, struct nk_color cbg, struct nk_color cfg)
 {
     int tx, ty;
+    unsigned long bg = nk_color_from_byte(&cbg.r);
     unsigned long fg = nk_color_from_byte(&cfg.r);
-    (void)cbg;
+
+    XSetForeground(surf->dpy, surf->gc, bg);
+    XFillRectangle(surf->dpy, surf->drawable, surf->gc, (int)x, (int)y, (unsigned)w, (unsigned)h);
+    if(!text || !font || !len) return;
 
     tx = (int)x;
     ty = (int)y + font->ascent;


### PR DESCRIPTION
1. Main background area was filled by 2 big overlapping rectangles. It works good on solid but not on semi-transparent themes. Just replaced 2 big rectangles with 1 big and 2 small.
2. There is no need in [nk_gdip_fill_rect filled pies fix](https://github.com/vurtun/nuklear/commit/7ab7327fa492298d5fa85a40340892905f3995fc) anymore. It disturbs semi-transparent themes too.