### PR TITLE
Improvement to SFML GL2 demo code

### DIFF
--- a/demo/sfml_opengl2/nuklear_sfml_gl2.h
+++ b/demo/sfml_opengl2/nuklear_sfml_gl2.h
@@ -81,6 +81,9 @@ nk_sfml_render(enum nk_anti_aliasing AA)
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
     glViewport(0, 0, (GLsizei)window_width, (GLsizei)window_height);
+    glMatrixMode(GL_TEXTURE);
+    glPushMatrix();
+    glLoadIdentity();
     glMatrixMode(GL_PROJECTION);
     glPushMatrix();
     glLoadIdentity();
@@ -165,6 +168,8 @@ nk_sfml_render(enum nk_anti_aliasing AA)
     glDisable(GL_TEXTURE_2D);
 
     glBindTexture(GL_TEXTURE_2D, 0);
+    glMatrixMode(GL_TEXTURE);
+    glPopMatrix();
     glMatrixMode(GL_MODELVIEW);
     glPopMatrix();
     glMatrixMode(GL_PROJECTION);


### PR DESCRIPTION
Adds protection of the texture matrix stack which allows the user to use sf::Sprites with this code unmodified otherwise.

Using sf::Sprites with this example code, results in the text rendering as blurred boxes and the window panels being extremely transparent. Protecting the texture stack prevents this so if someone copy pastes this code they are not frustrated.