### PR TITLE
Add osx build sfml demo

### DIFF
--- a/demo/sfml_opengl2/Makefile
+++ b/demo/sfml_opengl2/Makefile
@@ -19,12 +19,11 @@ else
 	SFML_DIR = /home/ricky/Libraries/SFML
 
 	UNAME_S := $(shell uname -s)
-  ifeq ($(UNAME_S),Darwin)
-	  LIBS =  -lsfml-window -lsfml-system -pthread -framework OpenGL
-  else
+	ifeq ($(UNAME_S),Darwin)
+		LIBS = -lsfml-window -lsfml-system -pthread -framework OpenGL
+	else
 		LIBS = -DSFML_STATIC -lsfml-window-s -lsfml-system-s -pthread -ludev -lGL -lX11 -lXrandr
-  endif
-
+	endif
 endif
 
 SFML_INC = -I $(SFML_DIR)/include

--- a/demo/sfml_opengl2/Makefile
+++ b/demo/sfml_opengl2/Makefile
@@ -8,7 +8,6 @@ CFLAGS = -s -O2
 SRC = main.cpp
 OBJ = $(SRC:.cpp=.o)
 
-# TODO: Mac Build
 ifeq ($(OS),Windows_NT)
 	# Edit the line below to point to your SFML folder on Windows
 	SFML_DIR = C:/Users/Ricky/MinGW-Libs/SFML
@@ -16,10 +15,16 @@ ifeq ($(OS),Windows_NT)
 	BIN := $(BIN).exe
 	LIBS = -lmingw32 -DSFML_STATIC -lsfml-window-s -lsfml-system-s -lopengl32 -lwinmm -lgdi32
 else
-	# Edit the line below to point to your SFML folder on Linux
+	# Edit the line below to point to your SFML folder on Linux/MacOS
 	SFML_DIR = /home/ricky/Libraries/SFML
 
-	LIBS = -DSFML_STATIC -lsfml-window-s -lsfml-system-s -pthread -ludev -lGL -lX11 -lXrandr
+	UNAME_S := $(shell uname -s)
+  ifeq ($(UNAME_S),Darwin)
+	  LIBS =  -lsfml-window -lsfml-system -pthread -framework OpenGL
+  else
+		LIBS = -DSFML_STATIC -lsfml-window-s -lsfml-system-s -pthread -ludev -lGL -lX11 -lXrandr
+  endif
+
 endif
 
 SFML_INC = -I $(SFML_DIR)/include

--- a/demo/sfml_opengl3/Makefile
+++ b/demo/sfml_opengl3/Makefile
@@ -21,11 +21,11 @@ else
 	GLAD_DIR = /home/ricky/Libraries/GLAD
 
 	UNAME_S := $(shell uname -s)
-  ifeq ($(UNAME_S),Darwin)
-	  LIBS = -lsfml-window -lsfml-system -pthread -framework OpenGL
-  else
-	  LIBS = -DSFML_STATIC -lsfml-window-s -lsfml-system-s -pthread -ludev -lGL -lX11 -lXrandr
-  endif
+	ifeq ($(UNAME_S),Darwin)
+		LIBS = -lsfml-window -lsfml-system -pthread -framework OpenGL
+	else
+		LIBS = -DSFML_STATIC -lsfml-window-s -lsfml-system-s -pthread -ludev -lGL -lX11 -lXrandr
+	endif
 endif
 
 SFML_INC = -I $(SFML_DIR)/include

--- a/demo/sfml_opengl3/Makefile
+++ b/demo/sfml_opengl3/Makefile
@@ -8,7 +8,6 @@ CFLAGS = -s -O2
 SRC = main.cpp
 OBJ = $(SRC:.cpp=.o)
 
-# TODO: Mac Build
 ifeq ($(OS),Windows_NT)
 	# Edit the line below to point to your SFML/GLAD folder on Windows
 	SFML_DIR = C:/Users/Ricky/MinGW-Libs/SFML
@@ -17,11 +16,16 @@ ifeq ($(OS),Windows_NT)
 	BIN := $(BIN).exe
 	LIBS = -lmingw32 -DSFML_STATIC -lsfml-window-s -lsfml-system-s -lopengl32 -lwinmm -lgdi32
 else
-	# Edit the line below to point to your SFML/GLAD folder on Linux
+	# Edit the line below to point to your SFML/GLAD folder on Linux/MacOS
 	SFML_DIR = /home/ricky/Libraries/SFML
 	GLAD_DIR = /home/ricky/Libraries/GLAD
 
-	LIBS = -DSFML_STATIC -lsfml-window-s -lsfml-system-s -pthread -ludev -lGL -lX11 -lXrandr
+	UNAME_S := $(shell uname -s)
+  ifeq ($(UNAME_S),Darwin)
+	  LIBS = -lsfml-window -lsfml-system -pthread -framework OpenGL
+  else
+	  LIBS = -DSFML_STATIC -lsfml-window-s -lsfml-system-s -pthread -ludev -lGL -lX11 -lXrandr
+  endif
 endif
 
 SFML_INC = -I $(SFML_DIR)/include


### PR DESCRIPTION
Added one conditional (same as in SDL examples) for MacOS build.

One should consider that I've used non-static linking (without -s flag); quite explained [https://en.sfml-dev.org/forums/index.php?topic=6162.0](here) by Hiura (SFML OSX developer):

> Using static libraries is a bad solution. I won't go into the details here; there are already so many discussions on the Web explaining why this is bad on Unix like OSes.

Thanks for great library!

Tested on macOS sierra 10.12.6