### PR TITLE
Use NK_DTOA in function nk_do_property

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -16115,11 +16115,11 @@ nk_do_property(nk_flags *ws,
             num_len = nk_strlen(string);
             break;
         case NK_PROPERTY_FLOAT:
-            nk_dtoa(string, (double)variant->value.f);
+            NK_DTOA(string, (double)variant->value.f);
             num_len = nk_string_float_limit(string, NK_MAX_FLOAT_PRECISION);
             break;
         case NK_PROPERTY_DOUBLE:
-            nk_dtoa(string, variant->value.d);
+            NK_DTOA(string, variant->value.d);
             num_len = nk_string_float_limit(string, NK_MAX_FLOAT_PRECISION);
             break;
         }


### PR DESCRIPTION
This modification makes it so the nk_do_property() function uses the user-defined NK_DTOA function instead of the internal nk_dtoa() function, as per the description below "Optional Defines":
```
    NK_DTOA
        You can define this to `dtoa` or your own double to string conversion
        implementation replacement. If not defined nuklear will use its own
        imprecise and possibly unsafe version (does not handle nan or infinity!).
        <!> If used it is only required to be defined for the implementation part <!>
```
Keep up the great work on Nuklear, really enjoying it so far!