### PR TITLE
Fix NK_INCLUDE_COMMAND_USERDATA usage with images.

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -7968,9 +7968,16 @@ nk_draw_list_push_image(struct nk_draw_list *list, nk_handle texture)
         nk_draw_list_push_command(list, nk_null_rect, texture);
     } else {
         struct nk_draw_command *prev = nk_draw_list_command_last(list);
-        if (prev->elem_count == 0)
+        if (prev->elem_count == 0) {
             prev->texture = texture;
-        else if (prev->texture.id != texture.id)
+#ifdef NK_INCLUDE_COMMAND_USERDATA
+            prev->userdata = list->userdata;
+#endif
+    } else if (prev->texture.id != texture.id
+#ifdef NK_INCLUDE_COMMAND_USERDATA
+               || prev->userdata.id != list->userdata.id
+#endif
+              )
             nk_draw_list_push_command(list, prev->clip_rect, texture);
     }
 }


### PR DESCRIPTION
If userdata is used with drawing images userdata was missing from
the first image command and also subsequent commands which draw the
same texture but with different user data were incorrectly merged together.

I believe that this shouldn't be the case if userdata is used for something like "custom shaders" as it is stated in the comment because the same image with different shaders should most likely be drawn with different commands.

Sadly formatting of these `#ifdef`s looks a bit nasty, especially one in the if condition. I'm open to any suggestions/fixes.

This fixes #511