### PR TITLE
Fix clang warning and implement explicit circle segment count

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -11784,9 +11784,7 @@ nk_font_init(struct nk_font *font, float pixel_height,
  * MIT license (see License.txt in http://www.upperbounds.net/download/ProggyClean.ttf.zip)
  * Download and more information at http://upperbounds.net
  *-----------------------------------------------------------------------------*/
-#ifdef NK_INCLUDE_DEFAULT_FONT
-
- #ifdef __clang__
+#ifdef __clang__
 #pragma clang diagnostic push
 
 #pragma clang diagnostic ignored "-Woverlength-strings"
@@ -11794,6 +11792,8 @@ nk_font_init(struct nk_font *font, float pixel_height,
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Woverlength-strings"
 #endif
+
+#ifdef NK_INCLUDE_DEFAULT_FONT
 
 NK_GLOBAL const char nk_proggy_clean_ttf_compressed_data_base85[11980+1] =
     "7])#######hV0qs'/###[),##/l:$#Q6>##5[n42>c-TH`->>#/e>11NNV=Bv(*:.F?uu#(gRU.o0XGH`$vhLG1hxt9?W`#,5LsCp#-i>.r$<$6pD>Lb';9Crc6tgXmKVeU2cD4Eo3R/"


### PR DESCRIPTION
Added ability to pass custom amount of segments in circle rendering as a part of #566. It does not change the old behavior, just adds a new int inside circle command structs. If the segment count is set to 0, nk_convert falls back on the segment count specified by the config.

Also fixed a warning generated by clang, due to diagnostic push being inside the default font's `#ifdef`, whereas the pop was outside of it.