### PR TITLE
nk_layout_peek() bugfix

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -19954,6 +19954,9 @@ nk_layout_peek(struct nk_rect *bounds, struct nk_context *ctx)
         layout->row.index = 0;
     }
     nk_layout_widget_space(bounds, ctx, win, nk_false);
+    if (!layout->row.index) {
+        bounds->x -= layout->row.item_offset;
+    }
     layout->at_y = y;
     layout->row.index = index;
 }


### PR DESCRIPTION
Fixes boundary fetching issues present in widgets organized by row templates.

It's difficult to describe the bug that occurs without the fix, so here's a comparison video that shows the bug and the bugfix side-by-side:
https://www.youtube.com/watch?v=oKRfy61Q4wU