### PR TITLE
Ignore binary files on linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 demo/*/*.exe
 demo/*/*.obj
+demo/*/bin/*
+example/bin/*
 docs/xml
 docs/build
 docs/src


### PR DESCRIPTION
Modified `.gitignore` to ignore products of compilation of linux.