### PR TITLE
Fix nk_colorf_hsva_f alpha calculation

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -6176,7 +6176,7 @@ nk_colorf_hsva_f(float *out_h, float *out_s,
     *out_h = NK_ABS(K + (in.g - in.b)/(6.0f * chroma + 1e-20f));
     *out_s = chroma / (in.r + 1e-20f);
     *out_v = in.r;
-    *out_a = (float)in.a / 255.0f;
+    *out_a = in.a;
 
 }
 


### PR DESCRIPTION
In revision 2891c6a, color picker's alpha bar moves incollectly when I drag the hue bar.
![2018-01-06](https://user-images.githubusercontent.com/18512546/34633516-f7669638-f2bf-11e7-8f0d-dba6b9d3fcde.png)
![2018-01-06 1](https://user-images.githubusercontent.com/18512546/34633518-fa0f8e94-f2bf-11e7-888f-c7fb70d65873.png)
I fixed it.

Thanks.
