### PR TITLE
Make ctx->begin 0 if ctx->end became 0.

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -18789,6 +18789,8 @@ nk_clear(struct nk_context *ctx)
             iter == ctx->active) {
             ctx->active = iter->prev;
             ctx->end = iter->prev;
+            if (!ctx->end)
+                ctx->begin = 0;
             if (ctx->active)
                 ctx->active->flags &= ~(unsigned)NK_WINDOW_ROM;
         }


### PR DESCRIPTION
Please check that it is appropriate in current logic for working with lists.

Fixes #634.
