### PR TITLE
d3d11 demo: release target view with ID3D11RenderTargetView_Release()…

### DIFF
--- a/demo/d3d11/main.c
+++ b/demo/d3d11/main.c
@@ -290,7 +290,7 @@ int main(void)
 
     ID3D11DeviceContext_ClearState(context);
     nk_d3d11_shutdown();
-    ID3D11ShaderResourceView_Release(rt_view);
+    ID3D11RenderTargetView_Release(rt_view);
     ID3D11DeviceContext_Release(context);
     ID3D11Device_Release(device);
     IDXGISwapChain_Release(swap_chain);


### PR DESCRIPTION
… and not with ID3D11ShaderResourceView_Release()