### PR TITLE
Fixed a case where rendering would randomly assert if a temporary buffer failed to be allocated

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -9553,7 +9553,6 @@ nk_draw_list_stroke_poly_line(struct nk_draw_list *list, const struct nk_vec2 *p
         nk_buffer_mark(list->vertices, NK_BUFFER_FRONT);
         size = pnt_size * ((thick_line) ? 5 : 3) * points_count;
         normals = (struct nk_vec2*) nk_buffer_alloc(list->vertices, NK_BUFFER_FRONT, size, pnt_align);
-        NK_ASSERT(normals);
         if (!normals) return;
         temp = normals + points_count;
 
@@ -9790,7 +9789,6 @@ nk_draw_list_fill_poly_convex(struct nk_draw_list *list,
         nk_buffer_mark(list->vertices, NK_BUFFER_FRONT);
         size = pnt_size * points_count;
         normals = (struct nk_vec2*) nk_buffer_alloc(list->vertices, NK_BUFFER_FRONT, size, pnt_align);
-        NK_ASSERT(normals);
         if (!normals) return;
         vtx = (void*)((nk_byte*)list->vertices->memory.ptr + vertex_offset);
 

--- a/src/nuklear_vertex.c
+++ b/src/nuklear_vertex.c
@@ -450,7 +450,6 @@ nk_draw_list_stroke_poly_line(struct nk_draw_list *list, const struct nk_vec2 *p
         nk_buffer_mark(list->vertices, NK_BUFFER_FRONT);
         size = pnt_size * ((thick_line) ? 5 : 3) * points_count;
         normals = (struct nk_vec2*) nk_buffer_alloc(list->vertices, NK_BUFFER_FRONT, size, pnt_align);
-        NK_ASSERT(normals);
         if (!normals) return;
         temp = normals + points_count;
 
@@ -687,7 +686,6 @@ nk_draw_list_fill_poly_convex(struct nk_draw_list *list,
         nk_buffer_mark(list->vertices, NK_BUFFER_FRONT);
         size = pnt_size * points_count;
         normals = (struct nk_vec2*) nk_buffer_alloc(list->vertices, NK_BUFFER_FRONT, size, pnt_align);
-        NK_ASSERT(normals);
         if (!normals) return;
         vtx = (void*)((nk_byte*)list->vertices->memory.ptr + vertex_offset);
 


### PR DESCRIPTION
Other parts of the draw_list code simply fail more or less silently when the buffers fill up. The user could allocate bigger buffers and try again, except that these particular functions assert when they fail to allocate the buffer.

Basically, the program would randomly assert sometimes, because it had used just enough buffer space that `nk_draw_list_stroke_poly_line` and `nk_draw_list_fill_poly_convex` would attempt to allocate a temporary buffer and fail. Unfortunately, I'm new to the library, so I don't fully understand the drawing code, but both asserts were followed by `if (!normals) return;`, so I just removed the asserts. To my understanding, rendering should fail soon afterwards, due to low buffer space. It may be better to have them return an error code, so rendering can fail more gracefully.

Was using nk_convert; I'm not sure if this issue affected other rendering paths.