### PR TITLE
Adding va_list versions of varargs functions

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -309,8 +309,10 @@ extern "C" {
   #endif
   #if defined(__GNUC__)
     #define NK_PRINTF_VARARG_FUNC(fmtargnumber) __attribute__((format(__printf__, fmtargnumber, fmtargnumber+1)))
+    #define NK_PRINTF_VALIST_FUNC(fmtargnumber) __attribute__((format(__printf__, fmtargnumber, 0)))
   #else
     #define NK_PRINTF_VARARG_FUNC(fmtargnumber)
+    #define NK_PRINTF_VALIST_FUNC(fmtargnumber)
   #endif
 #endif
 
@@ -3014,6 +3016,10 @@ NK_API void nk_labelf(struct nk_context*, nk_flags, NK_PRINTF_FORMAT_STRING cons
 NK_API void nk_labelf_colored(struct nk_context*, nk_flags, struct nk_color, NK_PRINTF_FORMAT_STRING const char*,...) NK_PRINTF_VARARG_FUNC(4);
 NK_API void nk_labelf_wrap(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*,...) NK_PRINTF_VARARG_FUNC(2);
 NK_API void nk_labelf_colored_wrap(struct nk_context*, struct nk_color, NK_PRINTF_FORMAT_STRING const char*,...) NK_PRINTF_VARARG_FUNC(3);
+NK_API void nk_labelfv(struct nk_context*, nk_flags, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(3);
+NK_API void nk_labelfv_colored(struct nk_context*, nk_flags, struct nk_color, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(4);
+NK_API void nk_labelfv_wrap(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(2);
+NK_API void nk_labelfv_colored_wrap(struct nk_context*, struct nk_color, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(3);
 NK_API void nk_value_bool(struct nk_context*, const char *prefix, int);
 NK_API void nk_value_int(struct nk_context*, const char *prefix, int);
 NK_API void nk_value_uint(struct nk_context*, const char *prefix, unsigned int);
@@ -3430,7 +3436,8 @@ NK_API void nk_contextual_end(struct nk_context*);
  * ============================================================================= */
 NK_API void nk_tooltip(struct nk_context*, const char*);
 #ifdef NK_INCLUDE_STANDARD_VARARGS
-NK_API void nk_tooltipf(struct nk_context*, const char*, ...);
+NK_API void nk_tooltipf(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, ...) NK_PRINTF_VARARG_FUNC(2);
++NK_API void nk_tooltipfv(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(2);
 #endif
 NK_API int nk_tooltip_begin(struct nk_context*, float width);
 NK_API void nk_tooltip_end(struct nk_context*);
@@ -18983,44 +18990,70 @@ NK_API void
 nk_labelf_colored(struct nk_context *ctx, nk_flags flags,
     struct nk_color color, const char *fmt, ...)
 {
-    char buf[256];
     va_list args;
     va_start(args, fmt);
-    nk_strfmt(buf, NK_LEN(buf), fmt, args);
-    nk_label_colored(ctx, buf, flags, color);
+    nk_labelfv_colored(ctx, flags, color, fmt, args);
     va_end(args);
 }
 NK_API void
 nk_labelf_colored_wrap(struct nk_context *ctx, struct nk_color color,
     const char *fmt, ...)
 {
-    char buf[256];
     va_list args;
     va_start(args, fmt);
-    nk_strfmt(buf, NK_LEN(buf), fmt, args);
-    nk_label_colored_wrap(ctx, buf, color);
+    nk_labelfv_colored_wrap(ctx, color, fmt, args);
     va_end(args);
 }
 NK_API void
 nk_labelf(struct nk_context *ctx, nk_flags flags, const char *fmt, ...)
 {
-    char buf[256];
     va_list args;
     va_start(args, fmt);
-    nk_strfmt(buf, NK_LEN(buf), fmt, args);
-    nk_label(ctx, buf, flags);
+    nk_labelfv(ctx, flags, fmt, args);
     va_end(args);
 }
 NK_API void
 nk_labelf_wrap(struct nk_context *ctx, const char *fmt,...)
 {
-    char buf[256];
     va_list args;
     va_start(args, fmt);
-    nk_strfmt(buf, NK_LEN(buf), fmt, args);
-    nk_label_wrap(ctx, buf);
+    nk_labelfv_wrap(ctx, fmt, args);
     va_end(args);
 }
+NK_API void
+nk_labelfv_colored(struct nk_context *ctx, nk_flags flags,
+    struct nk_color color, const char *fmt, va_list args)
+{
+    char buf[256];
+    nk_strfmt(buf, NK_LEN(buf), fmt, args);
+    nk_label_colored(ctx, buf, flags, color);
+}
+
+NK_API void
+nk_labelfv_colored_wrap(struct nk_context *ctx, struct nk_color color,
+    const char *fmt, va_list args)
+{
+    char buf[256];
+    nk_strfmt(buf, NK_LEN(buf), fmt, args);
+    nk_label_colored_wrap(ctx, buf, color);
+}
+
+NK_API void
+nk_labelfv(struct nk_context *ctx, nk_flags flags, const char *fmt, va_list args)
+{
+    char buf[256];
+    nk_strfmt(buf, NK_LEN(buf), fmt, args);
+    nk_label(ctx, buf, flags);
+}
+
+NK_API void
+nk_labelfv_wrap(struct nk_context *ctx, const char *fmt, va_list args)
+{
+    char buf[256];
+    nk_strfmt(buf, NK_LEN(buf), fmt, args);
+    nk_label_wrap(ctx, buf);
+}
+
 NK_API void
 nk_value_bool(struct nk_context *ctx, const char *prefix, int value)
 {
@@ -24859,11 +24892,16 @@ nk_tooltip(struct nk_context *ctx, const char *text)
 NK_API void
 nk_tooltipf(struct nk_context *ctx, const char *fmt, ...)
 {
-    char buf[256];
     va_list args;
     va_start(args, fmt);
-    nk_strfmt(buf, NK_LEN(buf), fmt, args);
+    nk_tooltipfv(ctx, fmt, args);
     va_end(args);
+}
+NK_API void
+nk_tooltipfv(struct nk_context *ctx, const char *fmt, va_list args)
+{
+    char buf[256];
+    nk_strfmt(buf, NK_LEN(buf), fmt, args);
     nk_tooltip(ctx, buf);
 }
 #endif

--- a/nuklear.h
+++ b/nuklear.h
@@ -3437,7 +3437,7 @@ NK_API void nk_contextual_end(struct nk_context*);
 NK_API void nk_tooltip(struct nk_context*, const char*);
 #ifdef NK_INCLUDE_STANDARD_VARARGS
 NK_API void nk_tooltipf(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, ...) NK_PRINTF_VARARG_FUNC(2);
-+NK_API void nk_tooltipfv(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(2);
+NK_API void nk_tooltipfv(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(2);
 #endif
 NK_API int nk_tooltip_begin(struct nk_context*, float width);
 NK_API void nk_tooltip_end(struct nk_context*);

--- a/src/nuklear.h
+++ b/src/nuklear.h
@@ -93,8 +93,10 @@ extern "C" {
   #endif
   #if defined(__GNUC__)
     #define NK_PRINTF_VARARG_FUNC(fmtargnumber) __attribute__((format(__printf__, fmtargnumber, fmtargnumber+1)))
+    #define NK_PRINTF_VALIST_FUNC(fmtargnumber) __attribute__((format(__printf__, fmtargnumber, 0)))
   #else
     #define NK_PRINTF_VARARG_FUNC(fmtargnumber)
+    #define NK_PRINTF_VALIST_FUNC(fmtargnumber)
   #endif
 #endif
 
@@ -2798,6 +2800,10 @@ NK_API void nk_labelf(struct nk_context*, nk_flags, NK_PRINTF_FORMAT_STRING cons
 NK_API void nk_labelf_colored(struct nk_context*, nk_flags, struct nk_color, NK_PRINTF_FORMAT_STRING const char*,...) NK_PRINTF_VARARG_FUNC(4);
 NK_API void nk_labelf_wrap(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*,...) NK_PRINTF_VARARG_FUNC(2);
 NK_API void nk_labelf_colored_wrap(struct nk_context*, struct nk_color, NK_PRINTF_FORMAT_STRING const char*,...) NK_PRINTF_VARARG_FUNC(3);
+NK_API void nk_labelfv(struct nk_context*, nk_flags, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(3);
+NK_API void nk_labelfv_colored(struct nk_context*, nk_flags, struct nk_color, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(4);
+NK_API void nk_labelfv_wrap(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(2);
+NK_API void nk_labelfv_colored_wrap(struct nk_context*, struct nk_color, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(3);
 NK_API void nk_value_bool(struct nk_context*, const char *prefix, int);
 NK_API void nk_value_int(struct nk_context*, const char *prefix, int);
 NK_API void nk_value_uint(struct nk_context*, const char *prefix, unsigned int);
@@ -3214,7 +3220,8 @@ NK_API void nk_contextual_end(struct nk_context*);
  * ============================================================================= */
 NK_API void nk_tooltip(struct nk_context*, const char*);
 #ifdef NK_INCLUDE_STANDARD_VARARGS
-NK_API void nk_tooltipf(struct nk_context*, const char*, ...);
+NK_API void nk_tooltipf(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, ...) NK_PRINTF_VARARG_FUNC(2);
++NK_API void nk_tooltipfv(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(2);
 #endif
 NK_API int nk_tooltip_begin(struct nk_context*, float width);
 NK_API void nk_tooltip_end(struct nk_context*);

--- a/src/nuklear.h
+++ b/src/nuklear.h
@@ -3221,7 +3221,7 @@ NK_API void nk_contextual_end(struct nk_context*);
 NK_API void nk_tooltip(struct nk_context*, const char*);
 #ifdef NK_INCLUDE_STANDARD_VARARGS
 NK_API void nk_tooltipf(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, ...) NK_PRINTF_VARARG_FUNC(2);
-+NK_API void nk_tooltipfv(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(2);
+NK_API void nk_tooltipfv(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(2);
 #endif
 NK_API int nk_tooltip_begin(struct nk_context*, float width);
 NK_API void nk_tooltip_end(struct nk_context*);

--- a/src/nuklear_text.c
+++ b/src/nuklear_text.c
@@ -150,44 +150,70 @@ NK_API void
 nk_labelf_colored(struct nk_context *ctx, nk_flags flags,
     struct nk_color color, const char *fmt, ...)
 {
-    char buf[256];
     va_list args;
     va_start(args, fmt);
-    nk_strfmt(buf, NK_LEN(buf), fmt, args);
-    nk_label_colored(ctx, buf, flags, color);
+    nk_labelfv_colored(ctx, flags, color, fmt, args);
     va_end(args);
 }
 NK_API void
 nk_labelf_colored_wrap(struct nk_context *ctx, struct nk_color color,
     const char *fmt, ...)
 {
-    char buf[256];
     va_list args;
     va_start(args, fmt);
-    nk_strfmt(buf, NK_LEN(buf), fmt, args);
-    nk_label_colored_wrap(ctx, buf, color);
+    nk_labelfv_colored_wrap(ctx, color, fmt, args);
     va_end(args);
 }
 NK_API void
 nk_labelf(struct nk_context *ctx, nk_flags flags, const char *fmt, ...)
 {
-    char buf[256];
     va_list args;
     va_start(args, fmt);
-    nk_strfmt(buf, NK_LEN(buf), fmt, args);
-    nk_label(ctx, buf, flags);
+    nk_labelfv(ctx, flags, fmt, args);
     va_end(args);
 }
 NK_API void
 nk_labelf_wrap(struct nk_context *ctx, const char *fmt,...)
 {
-    char buf[256];
     va_list args;
     va_start(args, fmt);
-    nk_strfmt(buf, NK_LEN(buf), fmt, args);
-    nk_label_wrap(ctx, buf);
+    nk_labelfv_wrap(ctx, fmt, args);
     va_end(args);
 }
+NK_API void
+nk_labelfv_colored(struct nk_context *ctx, nk_flags flags,
+    struct nk_color color, const char *fmt, va_list args)
+{
+    char buf[256];
+    nk_strfmt(buf, NK_LEN(buf), fmt, args);
+    nk_label_colored(ctx, buf, flags, color);
+}
+
+NK_API void
+nk_labelfv_colored_wrap(struct nk_context *ctx, struct nk_color color,
+    const char *fmt, va_list args)
+{
+    char buf[256];
+    nk_strfmt(buf, NK_LEN(buf), fmt, args);
+    nk_label_colored_wrap(ctx, buf, color);
+}
+
+NK_API void
+nk_labelfv(struct nk_context *ctx, nk_flags flags, const char *fmt, va_list args)
+{
+    char buf[256];
+    nk_strfmt(buf, NK_LEN(buf), fmt, args);
+    nk_label(ctx, buf, flags);
+}
+
+NK_API void
+nk_labelfv_wrap(struct nk_context *ctx, const char *fmt, va_list args)
+{
+    char buf[256];
+    nk_strfmt(buf, NK_LEN(buf), fmt, args);
+    nk_label_wrap(ctx, buf);
+}
+
 NK_API void
 nk_value_bool(struct nk_context *ctx, const char *prefix, int value)
 {

--- a/src/nuklear_tooltip.c
+++ b/src/nuklear_tooltip.c
@@ -94,11 +94,16 @@ nk_tooltip(struct nk_context *ctx, const char *text)
 NK_API void
 nk_tooltipf(struct nk_context *ctx, const char *fmt, ...)
 {
-    char buf[256];
     va_list args;
     va_start(args, fmt);
-    nk_strfmt(buf, NK_LEN(buf), fmt, args);
+    nk_tooltipfv(ctx, fmt, args);
     va_end(args);
+}
+NK_API void
+nk_tooltipfv(struct nk_context *ctx, const char *fmt, va_list args)
+{
+    char buf[256];
+    nk_strfmt(buf, NK_LEN(buf), fmt, args);
     nk_tooltip(ctx, buf);
 }
 #endif


### PR DESCRIPTION
The title says it all. This PR just adds va_list versions of the varargs functions, so the user can forward varargs to nuklear.