### PR TITLE
Fix `Error 65543: NSGL` on macOS

### DIFF
--- a/example/canvas.c
+++ b/example/canvas.c
@@ -410,6 +410,7 @@ int main(int argc, char *argv[])
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
     glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
     win = glfwCreateWindow(WINDOW_WIDTH, WINDOW_HEIGHT, "Demo", NULL, NULL);
     glfwMakeContextCurrent(win);
     glfwSetWindowUserPointer(win, &ctx);


### PR DESCRIPTION
## Forward compatibility (GLFW_OPENGL_FORWARD_COMPAT)
Fix for error 65543 on macOS:

> Error `65543`: NSGL: The targeted version of OS X only supports forward-compatible contexts for OpenGL 3.2 and above

Quote from [docs](http://www.glfw.org/docs/latest/window_guide.html):

> GLFW_OPENGL_FORWARD_COMPAT specifies whether the OpenGL context should be forward-compatible, i.e. one where all functionality deprecated in the requested version of OpenGL is removed. This must only be used if the requested OpenGL version is 3.0 or above.