### PR TITLE
Fix: VC++ warning cannot convert parameter.

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -18480,7 +18480,7 @@ nk_tree_element_base(struct nk_context *ctx, enum nk_tree_type type,
         state = nk_add_value(ctx, win, tree_hash, 0);
         *state = initial_state;
     } return nk_tree_element_image_push_hashed_base(ctx, type, img, title,
-        nk_strlen(title), state, selected);
+        nk_strlen(title), (enum nk_collapse_states*)state, selected);
 }
 NK_API int
 nk_tree_element_push_hashed(struct nk_context *ctx, enum nk_tree_type type,
@@ -20513,7 +20513,7 @@ nk_do_selectable(nk_flags *state, struct nk_command_buffer *out,
 
     /* draw selectable */
     if (style->draw_begin) style->draw_begin(out, style->userdata);
-    nk_draw_selectable(out, *state, style, *value, &bounds, 0,0,0, str, len, align, font);
+    nk_draw_selectable(out, *state, style, *value, &bounds, 0,0,NK_SYMBOL_NONE, str, len, align, font);
     if (style->draw_end) style->draw_end(out, style->userdata);
     return old_value != *value;
 }
@@ -20560,7 +20560,7 @@ nk_do_selectable_image(nk_flags *state, struct nk_command_buffer *out,
 
     /* draw selectable */
     if (style->draw_begin) style->draw_begin(out, style->userdata);
-    nk_draw_selectable(out, *state, style, *value, &bounds, &icon, img, 0, str, len, align, font);
+    nk_draw_selectable(out, *state, style, *value, &bounds, &icon, img, NK_SYMBOL_NONE, str, len, align, font);
     if (style->draw_end) style->draw_end(out, style->userdata);
     return old_value != *value;
 }

--- a/src/nuklear_selectable.c
+++ b/src/nuklear_selectable.c
@@ -87,7 +87,7 @@ nk_do_selectable(nk_flags *state, struct nk_command_buffer *out,
 
     /* draw selectable */
     if (style->draw_begin) style->draw_begin(out, style->userdata);
-    nk_draw_selectable(out, *state, style, *value, &bounds, 0,0,0, str, len, align, font);
+    nk_draw_selectable(out, *state, style, *value, &bounds, 0,0,NK_SYMBOL_NONE, str, len, align, font);
     if (style->draw_end) style->draw_end(out, style->userdata);
     return old_value != *value;
 }
@@ -134,7 +134,7 @@ nk_do_selectable_image(nk_flags *state, struct nk_command_buffer *out,
 
     /* draw selectable */
     if (style->draw_begin) style->draw_begin(out, style->userdata);
-    nk_draw_selectable(out, *state, style, *value, &bounds, &icon, img, 0, str, len, align, font);
+    nk_draw_selectable(out, *state, style, *value, &bounds, &icon, img, NK_SYMBOL_NONE, str, len, align, font);
     if (style->draw_end) style->draw_end(out, style->userdata);
     return old_value != *value;
 }

--- a/src/nuklear_tree.c
+++ b/src/nuklear_tree.c
@@ -317,7 +317,7 @@ nk_tree_element_base(struct nk_context *ctx, enum nk_tree_type type,
         state = nk_add_value(ctx, win, tree_hash, 0);
         *state = initial_state;
     } return nk_tree_element_image_push_hashed_base(ctx, type, img, title,
-        nk_strlen(title), state, selected);
+        nk_strlen(title), (enum nk_collapse_states*)state, selected);
 }
 NK_API int
 nk_tree_element_push_hashed(struct nk_context *ctx, enum nk_tree_type type,


### PR DESCRIPTION
In revision 3f99a80, VC++2017 generates a warning:

nuklear.h(18483): warning C4133: 'function': incompatible types - from 'nk_uint *' to 'nk_collapse_states *'

and VC++6.0 generates some errors:

nuklear.h(18483) : error C2664: 'nk_tree_element_image_push_hashed_base' : cannot convert parameter 6 from 'unsigned int *' to 'enum nk_collapse_states *'
nuklear.h(20516) : error C2664: 'nk_draw_selectable' : cannot convert parameter 8 from 'const int' to 'enum nk_symbol_type'
nuklear.h(20563) : error C2664: 'nk_draw_selectable' : cannot convert parameter 8 from 'const int' to 'enum nk_symbol_type'

I fixed it. Thanks.
