### PR TITLE
Boundings width adjusting, removal of gaps. (rounding errors)

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -18026,21 +18026,21 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
     panel_space = nk_layout_row_calculate_usable_space(&ctx->style, layout->type,
                                             layout->bounds.w, layout->row.columns);
 
-    #define FRAC(x) (x - (int)x) /* will be used to remove fookin gaps */
+    #define NK_FRAC(x) (x - (int)x) /* will be used to remove fookin gaps */
     /* calculate the width of one item inside the current layout space */
     switch (layout->row.type) {
     case NK_LAYOUT_DYNAMIC_FIXED: {
         /* scaling fixed size widgets item width */
         float w = NK_MAX(1.0f,panel_space) / (float)layout->row.columns;
         item_offset = (float)layout->row.index * w;
-        item_width = w + FRAC(item_offset);
+        item_width = w + NK_FRAC(item_offset);
         item_spacing = (float)layout->row.index * spacing.x;
     } break;
     case NK_LAYOUT_DYNAMIC_ROW: {
         /* scaling single ratio widget width */
         float w = layout->row.item_width * panel_space;
         item_offset = layout->row.item_offset;
-        item_width = w + FRAC(item_offset);
+        item_width = w + NK_FRAC(item_offset);
         item_spacing = 0;
 
         if (modify) {
@@ -18055,8 +18055,8 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
         bounds->x -= (float)*layout->offset_x;
         bounds->y = layout->at_y + (layout->row.height * layout->row.item.y);
         bounds->y -= (float)*layout->offset_y;
-        bounds->w = layout->bounds.w  * layout->row.item.w + FRAC(bounds->x);
-        bounds->h = layout->row.height * layout->row.item.h + FRAC(bounds->y);
+        bounds->w = layout->bounds.w  * layout->row.item.w + NK_FRAC(bounds->x);
+        bounds->h = layout->row.height * layout->row.item.h + NK_FRAC(bounds->y);
         return;
     }
     case NK_LAYOUT_DYNAMIC: {
@@ -18069,7 +18069,7 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
         w = (ratio * panel_space);
         item_spacing = (float)layout->row.index * spacing.x;
         item_offset = layout->row.item_offset;
-        item_width = w + FRAC(item_offset);
+        item_width = w + NK_FRAC(item_offset);
 
         if (modify) {
             layout->row.item_offset += w;
@@ -18115,11 +18115,11 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
         NK_ASSERT(layout->row.index < NK_MAX_LAYOUT_ROW_TEMPLATE_COLUMNS);
         w = layout->row.templates[layout->row.index];
         item_offset = layout->row.item_offset;
-        item_width = w + FRAC(item_offset);
+        item_width = w + NK_FRAC(item_offset);
         item_spacing = (float)layout->row.index * spacing.x;
         if (modify) layout->row.item_offset += w;
     } break;
-    #undef FRAC
+    #undef NK_FRAC
     default: NK_ASSERT(0); break;
     };
 

--- a/nuklear.h
+++ b/nuklear.h
@@ -18026,22 +18026,25 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
     panel_space = nk_layout_row_calculate_usable_space(&ctx->style, layout->type,
                                             layout->bounds.w, layout->row.columns);
 
+    #define FRAC(x) (x - (int)x) /* will be used to remove fookin gaps */
     /* calculate the width of one item inside the current layout space */
     switch (layout->row.type) {
     case NK_LAYOUT_DYNAMIC_FIXED: {
         /* scaling fixed size widgets item width */
-        item_width = NK_MAX(1.0f,panel_space) / (float)layout->row.columns;
-        item_offset = (float)layout->row.index * item_width;
+        float w = NK_MAX(1.0f,panel_space) / (float)layout->row.columns;
+        item_offset = (float)layout->row.index * w;
+        item_width = w + FRAC(item_offset);
         item_spacing = (float)layout->row.index * spacing.x;
     } break;
     case NK_LAYOUT_DYNAMIC_ROW: {
         /* scaling single ratio widget width */
-        item_width = layout->row.item_width * panel_space;
+        float w = layout->row.item_width * panel_space;
         item_offset = layout->row.item_offset;
+        item_width = w + FRAC(item_offset);
         item_spacing = 0;
 
         if (modify) {
-            layout->row.item_offset += item_width + spacing.x;
+            layout->row.item_offset += w + spacing.x;
             layout->row.filled += layout->row.item_width;
             layout->row.index = 0;
         }
@@ -18052,23 +18055,24 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
         bounds->x -= (float)*layout->offset_x;
         bounds->y = layout->at_y + (layout->row.height * layout->row.item.y);
         bounds->y -= (float)*layout->offset_y;
-        bounds->w = layout->bounds.w  * layout->row.item.w;
-        bounds->h = layout->row.height * layout->row.item.h;
+        bounds->w = layout->bounds.w  * layout->row.item.w + FRAC(bounds->x);
+        bounds->h = layout->row.height * layout->row.item.h + FRAC(bounds->y);
         return;
     }
     case NK_LAYOUT_DYNAMIC: {
         /* scaling arrays of panel width ratios for every widget */
-        float ratio;
+        float ratio, w;
         NK_ASSERT(layout->row.ratio);
         ratio = (layout->row.ratio[layout->row.index] < 0) ?
             layout->row.item_width : layout->row.ratio[layout->row.index];
 
+        w = (ratio * panel_space);
         item_spacing = (float)layout->row.index * spacing.x;
-        item_width = (ratio * panel_space);
         item_offset = layout->row.item_offset;
+        item_width = w + FRAC(item_offset);
 
         if (modify) {
-            layout->row.item_offset += item_width;
+            layout->row.item_offset += w;
             layout->row.filled += ratio;
         }
     } break;
@@ -18106,13 +18110,16 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
     } break;
     case NK_LAYOUT_TEMPLATE: {
         /* stretchy row layout with combined dynamic/static widget width*/
+        float w;
         NK_ASSERT(layout->row.index < layout->row.columns);
         NK_ASSERT(layout->row.index < NK_MAX_LAYOUT_ROW_TEMPLATE_COLUMNS);
-        item_width = layout->row.templates[layout->row.index];
+        w = layout->row.templates[layout->row.index];
         item_offset = layout->row.item_offset;
+        item_width = w + FRAC(item_offset);
         item_spacing = (float)layout->row.index * spacing.x;
-        if (modify) layout->row.item_offset += item_width;
+        if (modify) layout->row.item_offset += w;
     } break;
+    #undef FRAC
     default: NK_ASSERT(0); break;
     };
 

--- a/src/nuklear_layout.c
+++ b/src/nuklear_layout.c
@@ -605,22 +605,25 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
     panel_space = nk_layout_row_calculate_usable_space(&ctx->style, layout->type,
                                             layout->bounds.w, layout->row.columns);
 
+    #define FRAC(x) (x - (int)x) /* will be used to remove fookin gaps */
     /* calculate the width of one item inside the current layout space */
     switch (layout->row.type) {
     case NK_LAYOUT_DYNAMIC_FIXED: {
         /* scaling fixed size widgets item width */
-        item_width = NK_MAX(1.0f,panel_space) / (float)layout->row.columns;
-        item_offset = (float)layout->row.index * item_width;
+        float w = NK_MAX(1.0f,panel_space) / (float)layout->row.columns;
+        item_offset = (float)layout->row.index * w;
+        item_width = w + FRAC(item_offset);
         item_spacing = (float)layout->row.index * spacing.x;
     } break;
     case NK_LAYOUT_DYNAMIC_ROW: {
         /* scaling single ratio widget width */
-        item_width = layout->row.item_width * panel_space;
+        float w = layout->row.item_width * panel_space;
         item_offset = layout->row.item_offset;
+        item_width = w + FRAC(item_offset);
         item_spacing = 0;
 
         if (modify) {
-            layout->row.item_offset += item_width + spacing.x;
+            layout->row.item_offset += w + spacing.x;
             layout->row.filled += layout->row.item_width;
             layout->row.index = 0;
         }
@@ -631,23 +634,24 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
         bounds->x -= (float)*layout->offset_x;
         bounds->y = layout->at_y + (layout->row.height * layout->row.item.y);
         bounds->y -= (float)*layout->offset_y;
-        bounds->w = layout->bounds.w  * layout->row.item.w;
-        bounds->h = layout->row.height * layout->row.item.h;
+        bounds->w = layout->bounds.w  * layout->row.item.w + FRAC(bounds->x);
+        bounds->h = layout->row.height * layout->row.item.h + FRAC(bounds->y);
         return;
     }
     case NK_LAYOUT_DYNAMIC: {
         /* scaling arrays of panel width ratios for every widget */
-        float ratio;
+        float ratio, w;
         NK_ASSERT(layout->row.ratio);
         ratio = (layout->row.ratio[layout->row.index] < 0) ?
             layout->row.item_width : layout->row.ratio[layout->row.index];
 
+        w = (ratio * panel_space);
         item_spacing = (float)layout->row.index * spacing.x;
-        item_width = (ratio * panel_space);
         item_offset = layout->row.item_offset;
+        item_width = w + FRAC(item_offset);
 
         if (modify) {
-            layout->row.item_offset += item_width;
+            layout->row.item_offset += w;
             layout->row.filled += ratio;
         }
     } break;
@@ -685,13 +689,16 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
     } break;
     case NK_LAYOUT_TEMPLATE: {
         /* stretchy row layout with combined dynamic/static widget width*/
+        float w;
         NK_ASSERT(layout->row.index < layout->row.columns);
         NK_ASSERT(layout->row.index < NK_MAX_LAYOUT_ROW_TEMPLATE_COLUMNS);
-        item_width = layout->row.templates[layout->row.index];
+        w = layout->row.templates[layout->row.index];
         item_offset = layout->row.item_offset;
+        item_width = w + FRAC(item_offset);
         item_spacing = (float)layout->row.index * spacing.x;
-        if (modify) layout->row.item_offset += item_width;
+        if (modify) layout->row.item_offset += w;
     } break;
+    #undef FRAC
     default: NK_ASSERT(0); break;
     };
 

--- a/src/nuklear_layout.c
+++ b/src/nuklear_layout.c
@@ -605,21 +605,21 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
     panel_space = nk_layout_row_calculate_usable_space(&ctx->style, layout->type,
                                             layout->bounds.w, layout->row.columns);
 
-    #define FRAC(x) (x - (int)x) /* will be used to remove fookin gaps */
+    #define NK_FRAC(x) (x - (int)x) /* will be used to remove fookin gaps */
     /* calculate the width of one item inside the current layout space */
     switch (layout->row.type) {
     case NK_LAYOUT_DYNAMIC_FIXED: {
         /* scaling fixed size widgets item width */
         float w = NK_MAX(1.0f,panel_space) / (float)layout->row.columns;
         item_offset = (float)layout->row.index * w;
-        item_width = w + FRAC(item_offset);
+        item_width = w + NK_FRAC(item_offset);
         item_spacing = (float)layout->row.index * spacing.x;
     } break;
     case NK_LAYOUT_DYNAMIC_ROW: {
         /* scaling single ratio widget width */
         float w = layout->row.item_width * panel_space;
         item_offset = layout->row.item_offset;
-        item_width = w + FRAC(item_offset);
+        item_width = w + NK_FRAC(item_offset);
         item_spacing = 0;
 
         if (modify) {
@@ -634,8 +634,8 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
         bounds->x -= (float)*layout->offset_x;
         bounds->y = layout->at_y + (layout->row.height * layout->row.item.y);
         bounds->y -= (float)*layout->offset_y;
-        bounds->w = layout->bounds.w  * layout->row.item.w + FRAC(bounds->x);
-        bounds->h = layout->row.height * layout->row.item.h + FRAC(bounds->y);
+        bounds->w = layout->bounds.w  * layout->row.item.w + NK_FRAC(bounds->x);
+        bounds->h = layout->row.height * layout->row.item.h + NK_FRAC(bounds->y);
         return;
     }
     case NK_LAYOUT_DYNAMIC: {
@@ -648,7 +648,7 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
         w = (ratio * panel_space);
         item_spacing = (float)layout->row.index * spacing.x;
         item_offset = layout->row.item_offset;
-        item_width = w + FRAC(item_offset);
+        item_width = w + NK_FRAC(item_offset);
 
         if (modify) {
             layout->row.item_offset += w;
@@ -694,11 +694,11 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
         NK_ASSERT(layout->row.index < NK_MAX_LAYOUT_ROW_TEMPLATE_COLUMNS);
         w = layout->row.templates[layout->row.index];
         item_offset = layout->row.item_offset;
-        item_width = w + FRAC(item_offset);
+        item_width = w + NK_FRAC(item_offset);
         item_spacing = (float)layout->row.index * spacing.x;
         if (modify) layout->row.item_offset += w;
     } break;
-    #undef FRAC
+    #undef NK_FRAC
     default: NK_ASSERT(0); break;
     };
 


### PR DESCRIPTION
There was an issue with dynamically placed widgets that provoked the appearance of gaps, which is undoubtedly bad in terms of the graphical interface.

You could see, that closely placed widgets, could cause strange anomails caused by that:
![image](https://user-images.githubusercontent.com/35467995/42409744-98af6860-81e7-11e8-9e6e-c82915f2c425.png)

You could check by your own.
Try this code and resize window, you will see gaps betwen green buttons:
```
		int i;		

		#define s ctx->style	
		s.button.border = s.button.rounding = 0;
		s.window.spacing  = nk_vec2(0, 0);
		#undef s

		nk_layout_row_dynamic(ctx, 50, 7);
		for (i = 0; i < 7; i++)
			nk_button_color(ctx, nk_rgb(0,255,0));
```

Well, the main problem is that widget offset always gets rounded different ways, while its width is constant.

This patch is intended to correct major holes and make gui look more fancy :)
(still possible few minor gaps. But i'll work on it to cover more and more in the future)

Also, this is my first ever pull, so be careful and check this code for an issues!