### PR TITLE
Fix issue 548

### DIFF
--- a/demo/glfw_opengl2/main.c
+++ b/demo/glfw_opengl2/main.c
@@ -21,6 +21,7 @@
 #define NK_INCLUDE_DEFAULT_FONT
 #define NK_IMPLEMENTATION
 #define NK_GLFW_GL2_IMPLEMENTATION
+#define NK_KEYSTATE_BASED_INPUT
 #include "../../nuklear.h"
 #include "nuklear_glfw_gl2.h"
 
@@ -37,7 +38,7 @@
 /*#define INCLUDE_ALL */
 /*#define INCLUDE_STYLE */
 /*#define INCLUDE_CALCULATOR */
-/*#define INCLUDE_OVERVIEW */
+#define INCLUDE_OVERVIEW
 /*#define INCLUDE_NODE_EDITOR */
 
 #ifdef INCLUDE_ALL

--- a/demo/glfw_opengl3/main.c
+++ b/demo/glfw_opengl3/main.c
@@ -22,6 +22,7 @@
 #define NK_INCLUDE_DEFAULT_FONT
 #define NK_IMPLEMENTATION
 #define NK_GLFW_GL3_IMPLEMENTATION
+#define NK_KEYSTATE_BASED_INPUT
 #include "../../nuklear.h"
 #include "nuklear_glfw_gl3.h"
 
@@ -41,7 +42,7 @@
 /*#define INCLUDE_ALL */
 /*#define INCLUDE_STYLE */
 /*#define INCLUDE_CALCULATOR */
-/*#define INCLUDE_OVERVIEW */
+#define INCLUDE_OVERVIEW
 /*#define INCLUDE_NODE_EDITOR */
 
 #ifdef INCLUDE_ALL

--- a/demo/glfw_opengl4/main.c
+++ b/demo/glfw_opengl4/main.c
@@ -22,6 +22,7 @@
 #define NK_INCLUDE_DEFAULT_FONT
 #define NK_IMPLEMENTATION
 #define NK_GLFW_GL4_IMPLEMENTATION
+#define NK_KEYSTATE_BASED_INPUT
 #include "../../nuklear.h"
 #include "nuklear_glfw_gl4.h"
 
@@ -41,7 +42,7 @@
 /*#define INCLUDE_ALL */
 /*#define INCLUDE_STYLE */
 /*#define INCLUDE_CALCULATOR */
-/*#define INCLUDE_OVERVIEW */
+#define INCLUDE_OVERVIEW
 /*#define INCLUDE_NODE_EDITOR */
 
 #ifdef INCLUDE_ALL

--- a/nuklear.h
+++ b/nuklear.h
@@ -106,6 +106,7 @@
 /// NK_BUTTON_TRIGGER_ON_RELEASE    | Different platforms require button clicks occurring either on buttons being pressed (up to down) or released (down to up). By default this library will react on buttons being pressed, but if you define this it will only trigger if a button is released.
 /// NK_ZERO_COMMAND_MEMORY          | Defining this will zero out memory for each drawing command added to a drawing queue (inside nk_command_buffer_push). Zeroing command memory is very useful for fast checking (using memcmp) if command buffers are equal and avoid drawing frames when nothing on screen has changed since previous frame.
 /// NK_UINT_DRAW_INDEX              | Defining this will set the size of vertex index elements when using NK_VERTEX_BUFFER_OUTPUT to 32bit instead of the default of 16bit
+/// NK_KEYSTATE_BASED_INPUT         | Define this if your backend uses key state for each frame rather than key press/release events
 ///
 /// !!! WARNING
 ///     The following flags will pull in the standard C library:

--- a/nuklear.h
+++ b/nuklear.h
@@ -13922,8 +13922,12 @@ nk_input_key(struct nk_context *ctx, enum nk_keys key, int down)
     NK_ASSERT(ctx);
     if (!ctx) return;
     in = &ctx->input;
+#ifdef NK_KEYSTATE_BASED_INPUT
     if (in->keyboard.keys[key].down != down)
         in->keyboard.keys[key].clicked++;
+#else
+    in->keyboard.keys[key].clicked++;
+#endif
     in->keyboard.keys[key].down = down;
 }
 NK_API void

--- a/nuklear.h
+++ b/nuklear.h
@@ -674,8 +674,8 @@ NK_API void nk_set_user_data(struct nk_context*, nk_handle handle);
 /*/// ### Input
 /// The input API is responsible for holding the current input state composed of
 /// mouse, key and text input states.
-/// It is worth noting that no direct os or window handling is done in nuklear.
-/// Instead all input state has to be provided by platform specific code. This in one hand
+/// It is worth noting that no direct OS or window handling is done in nuklear.
+/// Instead all input state has to be provided by platform specific code. This on one hand
 /// expects more work from the user and complicates usage but on the other hand
 /// provides simple abstraction over a big number of platforms, libraries and other
 /// already provided functionality.
@@ -776,7 +776,7 @@ enum nk_buttons {
 };
 /*/// #### nk_input_begin
 /// Begins the input mirroring process by resetting text, scroll
-/// mouse previous mouse position and movement as well as key state transitions,
+/// mouse, previous mouse position and movement as well as key state transitions,
 ///
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
 /// void nk_input_begin(struct nk_context*);
@@ -802,7 +802,7 @@ NK_API void nk_input_begin(struct nk_context*);
 */
 NK_API void nk_input_motion(struct nk_context*, int x, int y);
 /*/// #### nk_input_key
-/// Mirrors state of a specific key to nuklear
+/// Mirrors the state of a specific key to nuklear
 ///
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
 /// void nk_input_key(struct nk_context*, enum nk_keys key, int down);
@@ -834,6 +834,7 @@ NK_API void nk_input_button(struct nk_context*, enum nk_buttons, int x, int y, i
 /*/// #### nk_input_scroll
 /// Copies the last mouse scroll value to nuklear. Is generally
 /// a scroll value. So does not have to come from mouse and could also originate
+/// TODO finish this sentence
 ///
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
 /// void nk_input_scroll(struct nk_context *ctx, struct nk_vec2 val);
@@ -898,7 +899,7 @@ NK_API void nk_input_glyph(struct nk_context*, const nk_glyph);
 NK_API void nk_input_unicode(struct nk_context*, nk_rune);
 /*/// #### nk_input_end
 /// End the input mirroring process by resetting mouse grabbing
-/// state to ensure the mouse cursor is not grabbed indefinitely.///
+/// state to ensure the mouse cursor is not grabbed indefinitely.
 ///
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
 /// void nk_input_end(struct nk_context *ctx);
@@ -1178,7 +1179,7 @@ struct nk_convert_config {
 */
 NK_API const struct nk_command* nk__begin(struct nk_context*);
 /*/// #### nk__next
-/// Returns a draw command list iterator to iterate all draw
+/// Returns draw command pointer pointing to the next command inside the draw command list
 ///
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
 /// const struct nk_command* nk__next(struct nk_context*, const struct nk_command*);
@@ -1204,7 +1205,7 @@ NK_API const struct nk_command* nk__next(struct nk_context*, const struct nk_com
 /// __ctx__     | Must point to an previously initialized `nk_context` struct at the end of a frame
 /// __cmd__     | Command pointer initialized to NULL
 ///
-/// Returns draw command pointer pointing to the next command inside the draw command list
+/// Iterates over each draw command inside the context draw command list
 */
 #define nk_foreach(c, ctx) for((c) = nk__begin(ctx); (c) != 0; (c) = nk__next(ctx,c))
 #ifdef NK_INCLUDE_VERTEX_BUFFER_OUTPUT
@@ -1239,7 +1240,7 @@ NK_API const struct nk_command* nk__next(struct nk_context*, const struct nk_com
 */
 NK_API nk_flags nk_convert(struct nk_context*, struct nk_buffer *cmds, struct nk_buffer *vertices, struct nk_buffer *elements, const struct nk_convert_config*);
 /*/// #### nk__draw_begin
-/// Returns a draw vertex command buffer iterator to iterate each the vertex draw command buffer
+/// Returns a draw vertex command buffer iterator to iterate over the vertex draw command buffer
 ///
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
 /// const struct nk_draw_command* nk__draw_begin(const struct nk_context*, const struct nk_buffer*);
@@ -1307,7 +1308,7 @@ NK_API const struct nk_draw_command* nk__draw_next(const struct nk_draw_command*
 /// ### Window
 /// Windows are the main persistent state used inside nuklear and are life time
 /// controlled by simply "retouching" (i.e. calling) each window each frame.
-/// All widgets inside nuklear can only be added inside function pair `nk_begin_xxx`
+/// All widgets inside nuklear can only be added inside the function pair `nk_begin_xxx`
 /// and `nk_end`. Calling any widgets outside these two functions will result in an
 /// assert in debug or no state change in release mode.<br /><br />
 ///
@@ -1478,7 +1479,7 @@ enum nk_panel_flags {
 NK_API int nk_begin(struct nk_context *ctx, const char *title, struct nk_rect bounds, nk_flags flags);
 /*/// #### nk_begin_titled
 /// Extended window start with separated title and identifier to allow multiple
-/// windows with same name but not title
+/// windows with same title but not name
 ///
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
 /// int nk_begin_titled(struct nk_context *ctx, const char *name, const char *title, struct nk_rect bounds, nk_flags flags);
@@ -1522,12 +1523,12 @@ NK_API void nk_end(struct nk_context *ctx);
 /// __name__    | Window identifier
 ///
 /// Returns a `nk_window` struct pointing to the identified window or NULL if
-/// no window with given name was found
+/// no window with the given name was found
 */
 NK_API struct nk_window *nk_window_find(struct nk_context *ctx, const char *name);
 /*/// #### nk_window_get_bounds
-///
 /// Returns a rectangle with screen position and size of the currently processed window
+///
 /// !!! WARNING
 ///     Only call this function between calls `nk_begin_xxx` and `nk_end`
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
@@ -1541,9 +1542,9 @@ NK_API struct nk_window *nk_window_find(struct nk_context *ctx, const char *name
 /// Returns a `nk_rect` struct with window upper left window position and size
 */
 NK_API struct nk_rect nk_window_get_bounds(const struct nk_context *ctx);
-/*/// #### nk_window_get_bounds
-///
+/*/// #### nk_window_get_position
 /// Returns the position of the currently processed window.
+///
 /// !!! WARNING
 ///     Only call this function between calls `nk_begin_xxx` and `nk_end`
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
@@ -1558,8 +1559,8 @@ NK_API struct nk_rect nk_window_get_bounds(const struct nk_context *ctx);
 */
 NK_API struct nk_vec2 nk_window_get_position(const struct nk_context *ctx);
 /*/// #### nk_window_get_size
-///
 /// Returns the size with width and height of the currently processed window.
+///
 /// !!! WARNING
 ///     Only call this function between calls `nk_begin_xxx` and `nk_end`
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
@@ -1574,8 +1575,8 @@ NK_API struct nk_vec2 nk_window_get_position(const struct nk_context *ctx);
 */
 NK_API struct nk_vec2 nk_window_get_size(const struct nk_context*);
 /*/// #### nk_window_get_width
-///
 /// Returns the width of the currently processed window.
+///
 /// !!! WARNING
 ///     Only call this function between calls `nk_begin_xxx` and `nk_end`
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
@@ -1590,8 +1591,8 @@ NK_API struct nk_vec2 nk_window_get_size(const struct nk_context*);
 */
 NK_API float nk_window_get_width(const struct nk_context*);
 /*/// #### nk_window_get_height
-///
 /// Returns the height of the currently processed window.
+///
 /// !!! WARNING
 ///     Only call this function between calls `nk_begin_xxx` and `nk_end`
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
@@ -1606,12 +1607,12 @@ NK_API float nk_window_get_width(const struct nk_context*);
 */
 NK_API float nk_window_get_height(const struct nk_context*);
 /*/// #### nk_window_get_panel
-///
 /// Returns the underlying panel which contains all processing state of the current window.
+///
 /// !!! WARNING
 ///     Only call this function between calls `nk_begin_xxx` and `nk_end`
 /// !!! WARNING
-///     Do not keep the returned panel pointer around it is only valid until `nk_end`
+///     Do not keep the returned panel pointer around, it is only valid until `nk_end`
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
 /// struct nk_panel* nk_window_get_panel(struct nk_context *ctx);
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1624,9 +1625,9 @@ NK_API float nk_window_get_height(const struct nk_context*);
 */
 NK_API struct nk_panel* nk_window_get_panel(struct nk_context*);
 /*/// #### nk_window_get_content_region
-///
 /// Returns the position and size of the currently visible and non-clipped space
 /// inside the currently processed window.
+///
 /// !!! WARNING
 ///     Only call this function between calls `nk_begin_xxx` and `nk_end`
 ///
@@ -1643,9 +1644,9 @@ NK_API struct nk_panel* nk_window_get_panel(struct nk_context*);
 */
 NK_API struct nk_rect nk_window_get_content_region(struct nk_context*);
 /*/// #### nk_window_get_content_region_min
-///
 /// Returns the upper left position of the currently visible and non-clipped
 /// space inside the currently processed window.
+///
 /// !!! WARNING
 ///     Only call this function between calls `nk_begin_xxx` and `nk_end`
 ///
@@ -1662,9 +1663,9 @@ NK_API struct nk_rect nk_window_get_content_region(struct nk_context*);
 */
 NK_API struct nk_vec2 nk_window_get_content_region_min(struct nk_context*);
 /*/// #### nk_window_get_content_region_max
-///
 /// Returns the lower right screen position of the currently visible and
 /// non-clipped space inside the currently processed window.
+///
 /// !!! WARNING
 ///     Only call this function between calls `nk_begin_xxx` and `nk_end`
 ///
@@ -1681,9 +1682,9 @@ NK_API struct nk_vec2 nk_window_get_content_region_min(struct nk_context*);
 */
 NK_API struct nk_vec2 nk_window_get_content_region_max(struct nk_context*);
 /*/// #### nk_window_get_content_region_size
-///
 /// Returns the size of the currently visible and non-clipped space inside the
 /// currently processed window
+///
 /// !!! WARNING
 ///     Only call this function between calls `nk_begin_xxx` and `nk_end`
 ///
@@ -2291,7 +2292,7 @@ NK_API float nk_layout_ratio_from_pixel(struct nk_context*, float pixel_width);
 /// __columns__ | Number of widget inside row
 */
 NK_API void nk_layout_row_dynamic(struct nk_context *ctx, float height, int cols);
-/*/// #### nk_layout_row_dynamic
+/*/// #### nk_layout_row_static
 /// Sets current row layout to fill @cols number of widgets
 /// in row with same @item_width horizontal size. Once called all subsequent widget
 /// calls greater than @cols will allocate a new row with same layout.
@@ -2481,7 +2482,7 @@ NK_API struct nk_rect nk_layout_space_bounds(struct nk_context*);
 /// Returns transformed `nk_vec2` in screen space coordinates
 */
 NK_API struct nk_vec2 nk_layout_space_to_screen(struct nk_context*, struct nk_vec2);
-/*/// #### nk_layout_space_to_screen
+/*/// #### nk_layout_space_to_local
 /// Converts vector from layout space into screen space
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
 /// struct nk_vec2 nk_layout_space_to_local(struct nk_context*, struct nk_vec2);
@@ -25276,6 +25277,8 @@ nk_tooltipfv(struct nk_context *ctx, const char *fmt, va_list args)
 ///    - [yy]: Minor version with non-breaking API and library changes
 ///    - [zz]: Bug fix version with no direct changes to API
 ///
+/// - 2018/10/31 (4.00.2) - Added NK_KEYSTATE_BASED_INPUT to "fix" state based backends
+                            like GLFW without breaking key repeat behavior on event based.
 /// - 2018/04/01 (4.00.1) - Fixed calling `nk_convert` multiple time per single frame
 /// - 2018/04/01 (4.00.0) - BREAKING CHANGE: nk_draw_list_clear no longer tries to
 ///                         clear provided buffers. So make sure to either free

--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -8,6 +8,8 @@
 ///    - [yy]: Minor version with non-breaking API and library changes
 ///    - [zz]: Bug fix version with no direct changes to API
 ///
+/// - 2018/10/31 (4.00.2) - Added NK_KEYSTATE_BASED_INPUT to "fix" state based backends
+                            like GLFW without breaking key repeat behavior on event based.
 /// - 2018/04/01 (4.00.1) - Fixed calling `nk_convert` multiple time per single frame
 /// - 2018/04/01 (4.00.0) - BREAKING CHANGE: nk_draw_list_clear no longer tries to
 ///                         clear provided buffers. So make sure to either free

--- a/src/HEADER
+++ b/src/HEADER
@@ -105,6 +105,7 @@
 /// NK_BUTTON_TRIGGER_ON_RELEASE    | Different platforms require button clicks occurring either on buttons being pressed (up to down) or released (down to up). By default this library will react on buttons being pressed, but if you define this it will only trigger if a button is released.
 /// NK_ZERO_COMMAND_MEMORY          | Defining this will zero out memory for each drawing command added to a drawing queue (inside nk_command_buffer_push). Zeroing command memory is very useful for fast checking (using memcmp) if command buffers are equal and avoid drawing frames when nothing on screen has changed since previous frame.
 /// NK_UINT_DRAW_INDEX              | Defining this will set the size of vertex index elements when using NK_VERTEX_BUFFER_OUTPUT to 32bit instead of the default of 16bit
+/// NK_KEYSTATE_BASED_INPUT         | Define this if your backend uses key state for each frame rather than key press/release events
 ///
 /// !!! WARNING
 ///     The following flags will pull in the standard C library:

--- a/src/nuklear_input.c
+++ b/src/nuklear_input.c
@@ -60,8 +60,12 @@ nk_input_key(struct nk_context *ctx, enum nk_keys key, int down)
     NK_ASSERT(ctx);
     if (!ctx) return;
     in = &ctx->input;
+#ifdef NK_KEYSTATE_BASED_INPUT
     if (in->keyboard.keys[key].down != down)
         in->keyboard.keys[key].clicked++;
+#else
+    in->keyboard.keys[key].clicked++;
+#endif
     in->keyboard.keys[key].down = down;
 }
 NK_API void


### PR DESCRIPTION
The issue was introduced in the fix for 416 (commit 8559aeb).

The original problem was (backspace and arrows moving too fast) is not a
nuklear problem but a GLFW problem.  Because of the way nuklear handles
input (it must be between input_begin and end), the key callback method
GLFW offers is not an option.

So we have to use glfwGetKey() which returns the current state of a key
not whether it was just pressed or released, so nuklear acts like it
was pressed every single frame, hence the "too fast" problem.

The fix checks for state change and discards the event if there was
no change.  This kills key repeat behavior (for named keys) on
*all* platforms which makes deleting or arrowing inconvenient.

Since there's no way to fix the shortcomings of a callback vs event
based input API, my "fix" just makes the original fix conditional
on a macro NK_KEYSTATE_BASED_INPUT