### PR TITLE
Fix last column of screen getting clipped

### DIFF
--- a/demo/d3d11/nuklear_d3d11.h
+++ b/demo/d3d11/nuklear_d3d11.h
@@ -358,7 +358,7 @@ nk_d3d11_handle_event(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
 }
 
 static void
-nk_d3d11_clipbard_paste(nk_handle usr, struct nk_text_edit *edit)
+nk_d3d11_clipboard_paste(nk_handle usr, struct nk_text_edit *edit)
 {
     (void)usr;
     if (IsClipboardFormatAvailable(CF_UNICODETEXT) && OpenClipboard(NULL))
@@ -392,7 +392,7 @@ nk_d3d11_clipbard_paste(nk_handle usr, struct nk_text_edit *edit)
 }
 
 static void
-nk_d3d11_clipbard_copy(nk_handle usr, const char *text, int len)
+nk_d3d11_clipboard_copy(nk_handle usr, const char *text, int len)
 {
     (void)usr;
     if (OpenClipboard(NULL))
@@ -427,8 +427,8 @@ nk_d3d11_init(ID3D11Device *device, int width, int height, unsigned int max_vert
     ID3D11Device_AddRef(device);
 
     nk_init_default(&d3d11.ctx, 0);
-    d3d11.ctx.clip.copy = nk_d3d11_clipbard_copy;
-    d3d11.ctx.clip.paste = nk_d3d11_clipbard_paste;
+    d3d11.ctx.clip.copy = nk_d3d11_clipboard_copy;
+    d3d11.ctx.clip.paste = nk_d3d11_clipboard_paste;
     d3d11.ctx.clip.userdata = nk_handle_ptr(0);
 
     nk_buffer_init_default(&d3d11.cmds);

--- a/demo/d3d9/main.c
+++ b/demo/d3d9/main.c
@@ -280,7 +280,7 @@ int main(void)
         {
             HRESULT hr;
             hr = IDirect3DDevice9_Clear(device, 0, NULL, D3DCLEAR_TARGET | D3DCLEAR_ZBUFFER | D3DCLEAR_STENCIL,
-                D3DCOLOR_COLORVALUE(bg.a, bg.r, bg.g, bg.b), 0.0f, 0);
+                D3DCOLOR_COLORVALUE(bg.r, bg.g, bg.b, bg.a), 0.0f, 0);
             NK_ASSERT(SUCCEEDED(hr));
 
             hr = IDirect3DDevice9_BeginScene(device);

--- a/demo/gdi/build.bat
+++ b/demo/gdi/build.bat
@@ -3,4 +3,4 @@
 rem This will use VS2015 for compiler
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
 
-cl /nologo /W3 /O2 /fp:fast /Gm- /Fedemo.exe main.c user32.lib gdi32.lib /link /incremental:no
+cl /nologo /W3 /O2 /fp:fast /Gm- /Fedemo.exe main.c user32.lib gdi32.lib Msimg32.lib /link /incremental:no

--- a/demo/gdi/nuklear_gdi.h
+++ b/demo/gdi/nuklear_gdi.h
@@ -113,9 +113,9 @@ nk_delete_image(struct nk_image * image)
 
 static void
 nk_gdi_draw_image(short x, short y, unsigned short w, unsigned short h,
-	struct nk_image img, struct nk_color col)
+    struct nk_image img, struct nk_color col)
 {
-    HBITMAP	hbm = img.handle.ptr;
+    HBITMAP hbm = img.handle.ptr;
     HDC     hDCBits;
     BITMAP  bitmap;
     
@@ -826,9 +826,9 @@ nk_gdi_render(struct nk_color clear)
         } break;
         case NK_COMMAND_RECT_MULTI_COLOR:
         case NK_COMMAND_IMAGE: {
-			const struct nk_command_image *i = (const struct nk_command_image *)cmd;
-			nk_gdi_draw_image(i->x, i->y, i->w, i->h, i->img, i->col);
-		} break;
+            const struct nk_command_image *i = (const struct nk_command_image *)cmd;
+            nk_gdi_draw_image(i->x, i->y, i->w, i->h, i->img, i->col);
+        } break;
         case NK_COMMAND_ARC:
         case NK_COMMAND_ARC_FILLED:
         default: break;

--- a/demo/gdi/nuklear_gdi.h
+++ b/demo/gdi/nuklear_gdi.h
@@ -465,7 +465,7 @@ nk_gdifont_del(GdiFont *font)
 }
 
 static void
-nk_gdi_clipbard_paste(nk_handle usr, struct nk_text_edit *edit)
+nk_gdi_clipboard_paste(nk_handle usr, struct nk_text_edit *edit)
 {
     (void)usr;
     if (IsClipboardFormatAvailable(CF_UNICODETEXT) && OpenClipboard(NULL))
@@ -499,7 +499,7 @@ nk_gdi_clipbard_paste(nk_handle usr, struct nk_text_edit *edit)
 }
 
 static void
-nk_gdi_clipbard_copy(nk_handle usr, const char *text, int len)
+nk_gdi_clipboard_copy(nk_handle usr, const char *text, int len)
 {
     if (OpenClipboard(NULL))
     {
@@ -540,8 +540,8 @@ nk_gdi_init(GdiFont *gdifont, HDC window_dc, unsigned int width, unsigned int he
     SelectObject(gdi.memory_dc, gdi.bitmap);
 
     nk_init_default(&gdi.ctx, font);
-    gdi.ctx.clip.copy = nk_gdi_clipbard_copy;
-    gdi.ctx.clip.paste = nk_gdi_clipbard_paste;
+    gdi.ctx.clip.copy = nk_gdi_clipboard_copy;
+    gdi.ctx.clip.paste = nk_gdi_clipboard_paste;
     return &gdi.ctx;
 }
 

--- a/demo/gdi/nuklear_gdi.h
+++ b/demo/gdi/nuklear_gdi.h
@@ -209,6 +209,58 @@ nk_gdi_fill_rect(HDC dc, short x, short y, unsigned short w,
         RoundRect(dc, x, y, x + w, y + h, r, r);
     }
 }
+static void
+nk_gdi_set_vertexColor(PTRIVERTEX tri, struct nk_color col)
+{
+    tri->Red   = col.r << 8;
+    tri->Green = col.g << 8;
+    tri->Blue  = col.b << 8;
+    tri->Alpha = 0xff << 8;
+}
+
+static void
+nk_gdi_rect_multi_color(HDC dc, short x, short y, unsigned short w,
+    unsigned short h, struct nk_color left, struct nk_color top,
+    struct nk_color right, struct nk_color bottom)
+{
+    BLENDFUNCTION alphaFunction;
+    GRADIENT_RECT gRect;
+    GRADIENT_TRIANGLE gTri[2];
+    TRIVERTEX vt[4];
+    alphaFunction.BlendOp = AC_SRC_OVER;
+    alphaFunction.BlendFlags = 0;
+    alphaFunction.SourceConstantAlpha = 0;
+    alphaFunction.AlphaFormat = AC_SRC_ALPHA;
+
+    /* TODO: This Case Needs Repair.*/
+    /* Top Left Corner */
+    vt[0].x     = x;
+    vt[0].y     = y;
+    nk_gdi_set_vertexColor(&vt[0], left);
+    /* Top Right Corner */
+    vt[1].x     = x+w;
+    vt[1].y     = y;
+    nk_gdi_set_vertexColor(&vt[1], top);
+    /* Bottom Left Corner */
+    vt[2].x     = x;
+    vt[2].y     = y+h;
+    nk_gdi_set_vertexColor(&vt[2], right);
+
+    /* Bottom Right Corner */
+    vt[3].x     = x+w;
+    vt[3].y     = y+h;
+    nk_gdi_set_vertexColor(&vt[3], bottom);
+
+    gTri[0].Vertex1 = 0;
+    gTri[0].Vertex2 = 1;
+    gTri[0].Vertex3 = 2;
+    gTri[1].Vertex1 = 2;
+    gTri[1].Vertex2 = 1;
+    gTri[1].Vertex3 = 3;
+    GdiGradientFill(dc, vt, 4, gTri, 2 , GRADIENT_FILL_TRIANGLE);
+    AlphaBlend(gdi.window_dc,  x, y, x+w, y+h,gdi.memory_dc, x, y, x+w, y+h,alphaFunction);
+
+}
 
 static void
 nk_gdi_fill_triangle(HDC dc, short x0, short y0, short x1,
@@ -420,6 +472,7 @@ static void
 nk_gdi_blit(HDC dc)
 {
     BitBlt(dc, 0, 0, gdi.width, gdi.height, gdi.memory_dc, 0, 0, SRCCOPY);
+
 }
 
 GdiFont*
@@ -824,7 +877,10 @@ nk_gdi_render(struct nk_color clear)
             nk_gdi_stroke_curve(memory_dc, q->begin, q->ctrl[0], q->ctrl[1],
                 q->end, q->line_thickness, q->color);
         } break;
-        case NK_COMMAND_RECT_MULTI_COLOR:
+        case NK_COMMAND_RECT_MULTI_COLOR: {
+            const struct nk_command_rect_multi_color *r = (const struct nk_command_rect_multi_color *)cmd;
+            nk_gdi_rect_multi_color(memory_dc, r->x, r->y,r->w, r->h, r->left, r->top, r->right, r->bottom);
+        } break;
         case NK_COMMAND_IMAGE: {
             const struct nk_command_image *i = (const struct nk_command_image *)cmd;
             nk_gdi_draw_image(i->x, i->y, i->w, i->h, i->img, i->col);

--- a/demo/gdip/nuklear_gdip.h
+++ b/demo/gdip/nuklear_gdip.h
@@ -740,7 +740,7 @@ nk_gdipfont_del(GdipFont *font)
 }
 
 static void
-nk_gdip_clipbard_paste(nk_handle usr, struct nk_text_edit *edit)
+nk_gdip_clipboard_paste(nk_handle usr, struct nk_text_edit *edit)
 {
     HGLOBAL mem;
     SIZE_T size;
@@ -792,7 +792,7 @@ nk_gdip_clipbard_paste(nk_handle usr, struct nk_text_edit *edit)
 }
 
 static void
-nk_gdip_clipbard_copy(nk_handle usr, const char *text, int len)
+nk_gdip_clipboard_copy(nk_handle usr, const char *text, int len)
 {
     HGLOBAL mem;
     wchar_t* wstr;
@@ -849,8 +849,8 @@ nk_gdip_init(HWND hwnd, unsigned int width, unsigned int height)
     for(i=0; i< sizeof(gdip.fontCollection)/sizeof(gdip.fontCollection[0]); i++)
         gdip.fontCollection[i] = NULL;
     nk_init_default(&gdip.ctx, NULL);
-    gdip.ctx.clip.copy = nk_gdip_clipbard_copy;
-    gdip.ctx.clip.paste = nk_gdip_clipbard_paste;
+    gdip.ctx.clip.copy = nk_gdip_clipboard_copy;
+    gdip.ctx.clip.paste = nk_gdip_clipboard_paste;
     gdip.curFontCollection = 0;
     return &gdip.ctx;
 }

--- a/demo/glfw_opengl2/main.c
+++ b/demo/glfw_opengl2/main.c
@@ -21,6 +21,7 @@
 #define NK_INCLUDE_DEFAULT_FONT
 #define NK_IMPLEMENTATION
 #define NK_GLFW_GL2_IMPLEMENTATION
+#define NK_KEYSTATE_BASED_INPUT
 #include "../../nuklear.h"
 #include "nuklear_glfw_gl2.h"
 
@@ -37,7 +38,7 @@
 /*#define INCLUDE_ALL */
 /*#define INCLUDE_STYLE */
 /*#define INCLUDE_CALCULATOR */
-/*#define INCLUDE_OVERVIEW */
+#define INCLUDE_OVERVIEW
 /*#define INCLUDE_NODE_EDITOR */
 
 #ifdef INCLUDE_ALL

--- a/demo/glfw_opengl2/nuklear_glfw_gl2.h
+++ b/demo/glfw_opengl2/nuklear_glfw_gl2.h
@@ -230,7 +230,7 @@ nk_glfw3_mouse_button_callback(GLFWwindow* window, int button, int action, int m
 }
 
 NK_INTERN void
-nk_glfw3_clipbard_paste(nk_handle usr, struct nk_text_edit *edit)
+nk_glfw3_clipboard_paste(nk_handle usr, struct nk_text_edit *edit)
 {
     const char *text = glfwGetClipboardString(glfw.win);
     if (text) nk_textedit_paste(edit, text, nk_strlen(text));
@@ -238,7 +238,7 @@ nk_glfw3_clipbard_paste(nk_handle usr, struct nk_text_edit *edit)
 }
 
 NK_INTERN void
-nk_glfw3_clipbard_copy(nk_handle usr, const char *text, int len)
+nk_glfw3_clipboard_copy(nk_handle usr, const char *text, int len)
 {
     char *str = 0;
     (void)usr;
@@ -261,8 +261,8 @@ nk_glfw3_init(GLFWwindow *win, enum nk_glfw_init_state init_state)
         glfwSetMouseButtonCallback(win, nk_glfw3_mouse_button_callback);
     }
     nk_init_default(&glfw.ctx, 0);
-    glfw.ctx.clip.copy = nk_glfw3_clipbard_copy;
-    glfw.ctx.clip.paste = nk_glfw3_clipbard_paste;
+    glfw.ctx.clip.copy = nk_glfw3_clipboard_copy;
+    glfw.ctx.clip.paste = nk_glfw3_clipboard_paste;
     glfw.ctx.clip.userdata = nk_handle_ptr(0);
     nk_buffer_init_default(&glfw.ogl.cmds);
 

--- a/demo/glfw_opengl3/main.c
+++ b/demo/glfw_opengl3/main.c
@@ -22,6 +22,7 @@
 #define NK_INCLUDE_DEFAULT_FONT
 #define NK_IMPLEMENTATION
 #define NK_GLFW_GL3_IMPLEMENTATION
+#define NK_KEYSTATE_BASED_INPUT
 #include "../../nuklear.h"
 #include "nuklear_glfw_gl3.h"
 
@@ -41,7 +42,7 @@
 /*#define INCLUDE_ALL */
 /*#define INCLUDE_STYLE */
 /*#define INCLUDE_CALCULATOR */
-/*#define INCLUDE_OVERVIEW */
+#define INCLUDE_OVERVIEW
 /*#define INCLUDE_NODE_EDITOR */
 
 #ifdef INCLUDE_ALL

--- a/demo/glfw_opengl3/nuklear_glfw_gl3.h
+++ b/demo/glfw_opengl3/nuklear_glfw_gl3.h
@@ -339,7 +339,7 @@ nk_glfw3_mouse_button_callback(GLFWwindow* window, int button, int action, int m
 }
 
 NK_INTERN void
-nk_glfw3_clipbard_paste(nk_handle usr, struct nk_text_edit *edit)
+nk_glfw3_clipboard_paste(nk_handle usr, struct nk_text_edit *edit)
 {
     const char *text = glfwGetClipboardString(glfw.win);
     if (text) nk_textedit_paste(edit, text, nk_strlen(text));
@@ -347,7 +347,7 @@ nk_glfw3_clipbard_paste(nk_handle usr, struct nk_text_edit *edit)
 }
 
 NK_INTERN void
-nk_glfw3_clipbard_copy(nk_handle usr, const char *text, int len)
+nk_glfw3_clipboard_copy(nk_handle usr, const char *text, int len)
 {
     char *str = 0;
     (void)usr;
@@ -370,8 +370,8 @@ nk_glfw3_init(GLFWwindow *win, enum nk_glfw_init_state init_state)
         glfwSetMouseButtonCallback(win, nk_glfw3_mouse_button_callback);
     }
     nk_init_default(&glfw.ctx, 0);
-    glfw.ctx.clip.copy = nk_glfw3_clipbard_copy;
-    glfw.ctx.clip.paste = nk_glfw3_clipbard_paste;
+    glfw.ctx.clip.copy = nk_glfw3_clipboard_copy;
+    glfw.ctx.clip.paste = nk_glfw3_clipboard_paste;
     glfw.ctx.clip.userdata = nk_handle_ptr(0);
     glfw.last_button_click = 0;
     nk_glfw3_device_create();

--- a/demo/glfw_opengl4/main.c
+++ b/demo/glfw_opengl4/main.c
@@ -22,6 +22,7 @@
 #define NK_INCLUDE_DEFAULT_FONT
 #define NK_IMPLEMENTATION
 #define NK_GLFW_GL4_IMPLEMENTATION
+#define NK_KEYSTATE_BASED_INPUT
 #include "../../nuklear.h"
 #include "nuklear_glfw_gl4.h"
 
@@ -41,7 +42,7 @@
 /*#define INCLUDE_ALL */
 /*#define INCLUDE_STYLE */
 /*#define INCLUDE_CALCULATOR */
-/*#define INCLUDE_OVERVIEW */
+#define INCLUDE_OVERVIEW
 /*#define INCLUDE_NODE_EDITOR */
 
 #ifdef INCLUDE_ALL

--- a/demo/glfw_opengl4/nuklear_glfw_gl4.h
+++ b/demo/glfw_opengl4/nuklear_glfw_gl4.h
@@ -489,7 +489,7 @@ nk_glfw3_mouse_button_callback(GLFWwindow* window, int button, int action, int m
 }
 
 NK_INTERN void
-nk_glfw3_clipbard_paste(nk_handle usr, struct nk_text_edit *edit)
+nk_glfw3_clipboard_paste(nk_handle usr, struct nk_text_edit *edit)
 {
     const char *text = glfwGetClipboardString(glfw.win);
     if (text) nk_textedit_paste(edit, text, nk_strlen(text));
@@ -497,7 +497,7 @@ nk_glfw3_clipbard_paste(nk_handle usr, struct nk_text_edit *edit)
 }
 
 NK_INTERN void
-nk_glfw3_clipbard_copy(nk_handle usr, const char *text, int len)
+nk_glfw3_clipboard_copy(nk_handle usr, const char *text, int len)
 {
     char *str = 0;
     (void)usr;
@@ -521,8 +521,8 @@ nk_glfw3_init(GLFWwindow *win, enum nk_glfw_init_state init_state,
         glfwSetMouseButtonCallback(win, nk_glfw3_mouse_button_callback);
     }
     nk_init_default(&glfw.ctx, 0);
-    glfw.ctx.clip.copy = nk_glfw3_clipbard_copy;
-    glfw.ctx.clip.paste = nk_glfw3_clipbard_paste;
+    glfw.ctx.clip.copy = nk_glfw3_clipboard_copy;
+    glfw.ctx.clip.paste = nk_glfw3_clipboard_paste;
     glfw.ctx.clip.userdata = nk_handle_ptr(0);
     glfw.last_button_click = 0;
 

--- a/demo/sdl_opengl2/nuklear_sdl_gl2.h
+++ b/demo/sdl_opengl2/nuklear_sdl_gl2.h
@@ -178,7 +178,7 @@ nk_sdl_render(enum nk_anti_aliasing AA)
 }
 
 static void
-nk_sdl_clipbard_paste(nk_handle usr, struct nk_text_edit *edit)
+nk_sdl_clipboard_paste(nk_handle usr, struct nk_text_edit *edit)
 {
     const char *text = SDL_GetClipboardText();
     if (text) nk_textedit_paste(edit, text, nk_strlen(text));
@@ -186,7 +186,7 @@ nk_sdl_clipbard_paste(nk_handle usr, struct nk_text_edit *edit)
 }
 
 static void
-nk_sdl_clipbard_copy(nk_handle usr, const char *text, int len)
+nk_sdl_clipboard_copy(nk_handle usr, const char *text, int len)
 {
     char *str = 0;
     (void)usr;
@@ -204,8 +204,8 @@ nk_sdl_init(SDL_Window *win)
 {
     sdl.win = win;
     nk_init_default(&sdl.ctx, 0);
-    sdl.ctx.clip.copy = nk_sdl_clipbard_copy;
-    sdl.ctx.clip.paste = nk_sdl_clipbard_paste;
+    sdl.ctx.clip.copy = nk_sdl_clipboard_copy;
+    sdl.ctx.clip.paste = nk_sdl_clipboard_paste;
     sdl.ctx.clip.userdata = nk_handle_ptr(0);
     nk_buffer_init_default(&sdl.ogl.cmds);
     return &sdl.ctx;

--- a/demo/sdl_opengl3/nuklear_sdl_gl3.h
+++ b/demo/sdl_opengl3/nuklear_sdl_gl3.h
@@ -286,7 +286,7 @@ nk_sdl_render(enum nk_anti_aliasing AA, int max_vertex_buffer, int max_element_b
 }
 
 static void
-nk_sdl_clipbard_paste(nk_handle usr, struct nk_text_edit *edit)
+nk_sdl_clipboard_paste(nk_handle usr, struct nk_text_edit *edit)
 {
     const char *text = SDL_GetClipboardText();
     if (text) nk_textedit_paste(edit, text, nk_strlen(text));
@@ -294,7 +294,7 @@ nk_sdl_clipbard_paste(nk_handle usr, struct nk_text_edit *edit)
 }
 
 static void
-nk_sdl_clipbard_copy(nk_handle usr, const char *text, int len)
+nk_sdl_clipboard_copy(nk_handle usr, const char *text, int len)
 {
     char *str = 0;
     (void)usr;
@@ -312,8 +312,8 @@ nk_sdl_init(SDL_Window *win)
 {
     sdl.win = win;
     nk_init_default(&sdl.ctx, 0);
-    sdl.ctx.clip.copy = nk_sdl_clipbard_copy;
-    sdl.ctx.clip.paste = nk_sdl_clipbard_paste;
+    sdl.ctx.clip.copy = nk_sdl_clipboard_copy;
+    sdl.ctx.clip.paste = nk_sdl_clipboard_paste;
     sdl.ctx.clip.userdata = nk_handle_ptr(0);
     nk_sdl_device_create();
     return &sdl.ctx;

--- a/demo/sdl_opengles2/Makefile
+++ b/demo/sdl_opengles2/Makefile
@@ -18,7 +18,10 @@ $(BIN): prepare
 	$(CC) $(SRC) $(CFLAGS) -o bin/$(BIN) $(LIBS)
 
 web: prepare
-	emcc $(SRC) -Os -s USE_SDL=2 -o bin/index.html 
+	emcc $(SRC) -Os -s USE_SDL=2 -o bin/index.html
+
+rpi: prepare
+	$(CC) $(SRC) $(CFLAGS) -o bin/$(BIN) `PKG_CONFIG_PATH=/opt/vc/lib/pkgconfig/ pkg-config --cflags --libs bcm_host brcmglesv2` `/usr/local/bin/sdl2-config --libs --cflags`
 
 prepare:
 	@mkdir -p bin

--- a/demo/sdl_opengles2/Readme.md
+++ b/demo/sdl_opengles2/Readme.md
@@ -1,0 +1,30 @@
+OpenGL ES
+=========
+
+OpenGL ES (OpenGL for Embedded Systems) it is a subset of OpenGL aimed to be simple and fast. It is designed for embedded systems, so for example, this demo could be a good point to start an Android application.
+
+
+Linux, Mac OS X
+---------------
+You can develop under your favorite modern Linux distro. Most of them support Open GL ES out of the box. But remember that implementation could be different and you have to test your application on the end device too.
+
+Just use `make` to build normal Linux / Mac OS X version.
+
+
+Emscripten
+----------
+Some other demos could be compiled into WebGL too. But the point of this demo is to be compiled without overhead and compatibility mode.
+
+`make web` to build a web-version using Emscripten.
+
+
+Raspberry Pi
+------------
+
+Accelerated Open GL ES2 output supported for Raspberry Pi too. But SDL2 in default Raspbian repositories is not supporting `rpi` video driver by default, so you have to compile SDL2 yourself.
+
+It is better to compile SDL2 without X11 support (*--disable-video-x11* configure option). Or use `export SDL_VIDEODRIVER=rpi` before each run of the application.
+
+More info can be found here: https://github.com/vurtun/nuklear/issues/748
+
+`make rpi` to build the demo on your Raspberry Pi board.

--- a/demo/sdl_opengles2/nuklear_sdl_gles2.h
+++ b/demo/sdl_opengles2/nuklear_sdl_gles2.h
@@ -287,7 +287,7 @@ nk_sdl_render(enum nk_anti_aliasing AA, int max_vertex_buffer, int max_element_b
 }
 
 static void
-nk_sdl_clipbard_paste(nk_handle usr, struct nk_text_edit *edit)
+nk_sdl_clipboard_paste(nk_handle usr, struct nk_text_edit *edit)
 {
     const char *text = SDL_GetClipboardText();
     if (text) nk_textedit_paste(edit, text, nk_strlen(text));
@@ -295,7 +295,7 @@ nk_sdl_clipbard_paste(nk_handle usr, struct nk_text_edit *edit)
 }
 
 static void
-nk_sdl_clipbard_copy(nk_handle usr, const char *text, int len)
+nk_sdl_clipboard_copy(nk_handle usr, const char *text, int len)
 {
     char *str = 0;
     (void)usr;
@@ -313,8 +313,8 @@ nk_sdl_init(SDL_Window *win)
 {
     sdl.win = win;
     nk_init_default(&sdl.ctx, 0);
-    sdl.ctx.clip.copy = nk_sdl_clipbard_copy;
-    sdl.ctx.clip.paste = nk_sdl_clipbard_paste;
+    sdl.ctx.clip.copy = nk_sdl_clipboard_copy;
+    sdl.ctx.clip.paste = nk_sdl_clipboard_paste;
     sdl.ctx.clip.userdata = nk_handle_ptr(0);
     nk_sdl_device_create();
     return &sdl.ctx;

--- a/demo/x11_rawfb/main.c
+++ b/demo/x11_rawfb/main.c
@@ -228,13 +228,13 @@ main(void)
 
         /* -------------- EXAMPLES ---------------- */
         #ifdef INCLUDE_CALCULATOR
-          calculator(ctx);
+          calculator(&rawfb->ctx);
         #endif
         #ifdef INCLUDE_OVERVIEW
-          overview(ctx);
+          overview(&rawfb->ctx);
         #endif
         #ifdef INCLUDE_NODE_EDITOR
-          node_editor(ctx);
+          node_editor(&rawfb->ctx);
         #endif
         /* ----------------------------------------- */
 

--- a/demo/x11_rawfb/nuklear_rawfb.h
+++ b/demo/x11_rawfb/nuklear_rawfb.h
@@ -218,8 +218,8 @@ nk_rawfb_stroke_line(const struct rawfb_context *rawfb,
             x1 = x0;
             x0 = tmp;
         }
-        x1 = MIN(rawfb->scissors.w - 1, x1);
-        x0 = MIN(rawfb->scissors.w - 1, x0);
+        x1 = MIN(rawfb->scissors.w, x1);
+        x0 = MIN(rawfb->scissors.w, x0);
         x1 = MAX(rawfb->scissors.x, x1);
         x0 = MAX(rawfb->scissors.x, x0);
         nk_rawfb_line_horizontal(rawfb, x0, y0, x1, col);

--- a/demo/x11_xft/nuklear_xlib.h
+++ b/demo/x11_xft/nuklear_xlib.h
@@ -430,7 +430,7 @@ nk_xsurf_draw_text(XSurface *surf, short x, short y, unsigned short w, unsigned 
         xrc.blue = cfg.b * 257;
         xrc.alpha = cfg.a * 257;
         XftColorAllocValue(surf->dpy, xlib.vis, xlib.cmap, &xrc, &color);
-        XftDrawString8(surf->ftdraw, &color, font->ft, tx, ty, (FcChar8*)text, len);
+        XftDrawStringUtf8(surf->ftdraw, &color, font->ft, tx, ty, (FcChar8*)text, len);
     }
 #else
     XSetForeground(surf->dpy, surf->gc, fg);
@@ -632,7 +632,7 @@ nk_xfont_get_text_width(nk_handle handle, float height, const char *text, int le
     XGlyphInfo g;
     if(!font || !text)
         return 0;
-    XftTextExtents8(xlib.dpy, font->ft, (FcChar8*)text, len, &g);
+    XftTextExtentsUtf8(xlib.dpy, font->ft, (FcChar8*)text, len, &g);
     return g.width;
 #else
     XRectangle r;

--- a/nuklear.h
+++ b/nuklear.h
@@ -106,6 +106,7 @@
 /// NK_BUTTON_TRIGGER_ON_RELEASE    | Different platforms require button clicks occurring either on buttons being pressed (up to down) or released (down to up). By default this library will react on buttons being pressed, but if you define this it will only trigger if a button is released.
 /// NK_ZERO_COMMAND_MEMORY          | Defining this will zero out memory for each drawing command added to a drawing queue (inside nk_command_buffer_push). Zeroing command memory is very useful for fast checking (using memcmp) if command buffers are equal and avoid drawing frames when nothing on screen has changed since previous frame.
 /// NK_UINT_DRAW_INDEX              | Defining this will set the size of vertex index elements when using NK_VERTEX_BUFFER_OUTPUT to 32bit instead of the default of 16bit
+/// NK_KEYSTATE_BASED_INPUT         | Define this if your backend uses key state for each frame rather than key press/release events
 ///
 /// !!! WARNING
 ///     The following flags will pull in the standard C library:

--- a/nuklear.h
+++ b/nuklear.h
@@ -13922,8 +13922,12 @@ nk_input_key(struct nk_context *ctx, enum nk_keys key, int down)
     NK_ASSERT(ctx);
     if (!ctx) return;
     in = &ctx->input;
+#ifdef NK_KEYSTATE_BASED_INPUT
     if (in->keyboard.keys[key].down != down)
         in->keyboard.keys[key].clicked++;
+#else
+    in->keyboard.keys[key].clicked++;
+#endif
     in->keyboard.keys[key].down = down;
 }
 NK_API void

--- a/nuklear.h
+++ b/nuklear.h
@@ -674,8 +674,8 @@ NK_API void nk_set_user_data(struct nk_context*, nk_handle handle);
 /*/// ### Input
 /// The input API is responsible for holding the current input state composed of
 /// mouse, key and text input states.
-/// It is worth noting that no direct os or window handling is done in nuklear.
-/// Instead all input state has to be provided by platform specific code. This in one hand
+/// It is worth noting that no direct OS or window handling is done in nuklear.
+/// Instead all input state has to be provided by platform specific code. This on one hand
 /// expects more work from the user and complicates usage but on the other hand
 /// provides simple abstraction over a big number of platforms, libraries and other
 /// already provided functionality.
@@ -776,7 +776,7 @@ enum nk_buttons {
 };
 /*/// #### nk_input_begin
 /// Begins the input mirroring process by resetting text, scroll
-/// mouse previous mouse position and movement as well as key state transitions,
+/// mouse, previous mouse position and movement as well as key state transitions,
 ///
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
 /// void nk_input_begin(struct nk_context*);
@@ -802,7 +802,7 @@ NK_API void nk_input_begin(struct nk_context*);
 */
 NK_API void nk_input_motion(struct nk_context*, int x, int y);
 /*/// #### nk_input_key
-/// Mirrors state of a specific key to nuklear
+/// Mirrors the state of a specific key to nuklear
 ///
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
 /// void nk_input_key(struct nk_context*, enum nk_keys key, int down);
@@ -834,6 +834,7 @@ NK_API void nk_input_button(struct nk_context*, enum nk_buttons, int x, int y, i
 /*/// #### nk_input_scroll
 /// Copies the last mouse scroll value to nuklear. Is generally
 /// a scroll value. So does not have to come from mouse and could also originate
+/// TODO finish this sentence
 ///
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
 /// void nk_input_scroll(struct nk_context *ctx, struct nk_vec2 val);
@@ -898,7 +899,7 @@ NK_API void nk_input_glyph(struct nk_context*, const nk_glyph);
 NK_API void nk_input_unicode(struct nk_context*, nk_rune);
 /*/// #### nk_input_end
 /// End the input mirroring process by resetting mouse grabbing
-/// state to ensure the mouse cursor is not grabbed indefinitely.///
+/// state to ensure the mouse cursor is not grabbed indefinitely.
 ///
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
 /// void nk_input_end(struct nk_context *ctx);
@@ -1178,7 +1179,7 @@ struct nk_convert_config {
 */
 NK_API const struct nk_command* nk__begin(struct nk_context*);
 /*/// #### nk__next
-/// Returns a draw command list iterator to iterate all draw
+/// Returns draw command pointer pointing to the next command inside the draw command list
 ///
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
 /// const struct nk_command* nk__next(struct nk_context*, const struct nk_command*);
@@ -1204,7 +1205,7 @@ NK_API const struct nk_command* nk__next(struct nk_context*, const struct nk_com
 /// __ctx__     | Must point to an previously initialized `nk_context` struct at the end of a frame
 /// __cmd__     | Command pointer initialized to NULL
 ///
-/// Returns draw command pointer pointing to the next command inside the draw command list
+/// Iterates over each draw command inside the context draw command list
 */
 #define nk_foreach(c, ctx) for((c) = nk__begin(ctx); (c) != 0; (c) = nk__next(ctx,c))
 #ifdef NK_INCLUDE_VERTEX_BUFFER_OUTPUT
@@ -1239,7 +1240,7 @@ NK_API const struct nk_command* nk__next(struct nk_context*, const struct nk_com
 */
 NK_API nk_flags nk_convert(struct nk_context*, struct nk_buffer *cmds, struct nk_buffer *vertices, struct nk_buffer *elements, const struct nk_convert_config*);
 /*/// #### nk__draw_begin
-/// Returns a draw vertex command buffer iterator to iterate each the vertex draw command buffer
+/// Returns a draw vertex command buffer iterator to iterate over the vertex draw command buffer
 ///
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
 /// const struct nk_draw_command* nk__draw_begin(const struct nk_context*, const struct nk_buffer*);
@@ -1307,7 +1308,7 @@ NK_API const struct nk_draw_command* nk__draw_next(const struct nk_draw_command*
 /// ### Window
 /// Windows are the main persistent state used inside nuklear and are life time
 /// controlled by simply "retouching" (i.e. calling) each window each frame.
-/// All widgets inside nuklear can only be added inside function pair `nk_begin_xxx`
+/// All widgets inside nuklear can only be added inside the function pair `nk_begin_xxx`
 /// and `nk_end`. Calling any widgets outside these two functions will result in an
 /// assert in debug or no state change in release mode.<br /><br />
 ///
@@ -1478,7 +1479,7 @@ enum nk_panel_flags {
 NK_API int nk_begin(struct nk_context *ctx, const char *title, struct nk_rect bounds, nk_flags flags);
 /*/// #### nk_begin_titled
 /// Extended window start with separated title and identifier to allow multiple
-/// windows with same name but not title
+/// windows with same title but not name
 ///
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
 /// int nk_begin_titled(struct nk_context *ctx, const char *name, const char *title, struct nk_rect bounds, nk_flags flags);
@@ -1522,12 +1523,12 @@ NK_API void nk_end(struct nk_context *ctx);
 /// __name__    | Window identifier
 ///
 /// Returns a `nk_window` struct pointing to the identified window or NULL if
-/// no window with given name was found
+/// no window with the given name was found
 */
 NK_API struct nk_window *nk_window_find(struct nk_context *ctx, const char *name);
 /*/// #### nk_window_get_bounds
-///
 /// Returns a rectangle with screen position and size of the currently processed window
+///
 /// !!! WARNING
 ///     Only call this function between calls `nk_begin_xxx` and `nk_end`
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
@@ -1541,9 +1542,9 @@ NK_API struct nk_window *nk_window_find(struct nk_context *ctx, const char *name
 /// Returns a `nk_rect` struct with window upper left window position and size
 */
 NK_API struct nk_rect nk_window_get_bounds(const struct nk_context *ctx);
-/*/// #### nk_window_get_bounds
-///
+/*/// #### nk_window_get_position
 /// Returns the position of the currently processed window.
+///
 /// !!! WARNING
 ///     Only call this function between calls `nk_begin_xxx` and `nk_end`
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
@@ -1558,8 +1559,8 @@ NK_API struct nk_rect nk_window_get_bounds(const struct nk_context *ctx);
 */
 NK_API struct nk_vec2 nk_window_get_position(const struct nk_context *ctx);
 /*/// #### nk_window_get_size
-///
 /// Returns the size with width and height of the currently processed window.
+///
 /// !!! WARNING
 ///     Only call this function between calls `nk_begin_xxx` and `nk_end`
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
@@ -1574,8 +1575,8 @@ NK_API struct nk_vec2 nk_window_get_position(const struct nk_context *ctx);
 */
 NK_API struct nk_vec2 nk_window_get_size(const struct nk_context*);
 /*/// #### nk_window_get_width
-///
 /// Returns the width of the currently processed window.
+///
 /// !!! WARNING
 ///     Only call this function between calls `nk_begin_xxx` and `nk_end`
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
@@ -1590,8 +1591,8 @@ NK_API struct nk_vec2 nk_window_get_size(const struct nk_context*);
 */
 NK_API float nk_window_get_width(const struct nk_context*);
 /*/// #### nk_window_get_height
-///
 /// Returns the height of the currently processed window.
+///
 /// !!! WARNING
 ///     Only call this function between calls `nk_begin_xxx` and `nk_end`
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
@@ -1606,12 +1607,12 @@ NK_API float nk_window_get_width(const struct nk_context*);
 */
 NK_API float nk_window_get_height(const struct nk_context*);
 /*/// #### nk_window_get_panel
-///
 /// Returns the underlying panel which contains all processing state of the current window.
+///
 /// !!! WARNING
 ///     Only call this function between calls `nk_begin_xxx` and `nk_end`
 /// !!! WARNING
-///     Do not keep the returned panel pointer around it is only valid until `nk_end`
+///     Do not keep the returned panel pointer around, it is only valid until `nk_end`
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
 /// struct nk_panel* nk_window_get_panel(struct nk_context *ctx);
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1624,9 +1625,9 @@ NK_API float nk_window_get_height(const struct nk_context*);
 */
 NK_API struct nk_panel* nk_window_get_panel(struct nk_context*);
 /*/// #### nk_window_get_content_region
-///
 /// Returns the position and size of the currently visible and non-clipped space
 /// inside the currently processed window.
+///
 /// !!! WARNING
 ///     Only call this function between calls `nk_begin_xxx` and `nk_end`
 ///
@@ -1643,9 +1644,9 @@ NK_API struct nk_panel* nk_window_get_panel(struct nk_context*);
 */
 NK_API struct nk_rect nk_window_get_content_region(struct nk_context*);
 /*/// #### nk_window_get_content_region_min
-///
 /// Returns the upper left position of the currently visible and non-clipped
 /// space inside the currently processed window.
+///
 /// !!! WARNING
 ///     Only call this function between calls `nk_begin_xxx` and `nk_end`
 ///
@@ -1662,9 +1663,9 @@ NK_API struct nk_rect nk_window_get_content_region(struct nk_context*);
 */
 NK_API struct nk_vec2 nk_window_get_content_region_min(struct nk_context*);
 /*/// #### nk_window_get_content_region_max
-///
 /// Returns the lower right screen position of the currently visible and
 /// non-clipped space inside the currently processed window.
+///
 /// !!! WARNING
 ///     Only call this function between calls `nk_begin_xxx` and `nk_end`
 ///
@@ -1681,9 +1682,9 @@ NK_API struct nk_vec2 nk_window_get_content_region_min(struct nk_context*);
 */
 NK_API struct nk_vec2 nk_window_get_content_region_max(struct nk_context*);
 /*/// #### nk_window_get_content_region_size
-///
 /// Returns the size of the currently visible and non-clipped space inside the
 /// currently processed window
+///
 /// !!! WARNING
 ///     Only call this function between calls `nk_begin_xxx` and `nk_end`
 ///
@@ -2291,7 +2292,7 @@ NK_API float nk_layout_ratio_from_pixel(struct nk_context*, float pixel_width);
 /// __columns__ | Number of widget inside row
 */
 NK_API void nk_layout_row_dynamic(struct nk_context *ctx, float height, int cols);
-/*/// #### nk_layout_row_dynamic
+/*/// #### nk_layout_row_static
 /// Sets current row layout to fill @cols number of widgets
 /// in row with same @item_width horizontal size. Once called all subsequent widget
 /// calls greater than @cols will allocate a new row with same layout.
@@ -2481,7 +2482,7 @@ NK_API struct nk_rect nk_layout_space_bounds(struct nk_context*);
 /// Returns transformed `nk_vec2` in screen space coordinates
 */
 NK_API struct nk_vec2 nk_layout_space_to_screen(struct nk_context*, struct nk_vec2);
-/*/// #### nk_layout_space_to_screen
+/*/// #### nk_layout_space_to_local
 /// Converts vector from layout space into screen space
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
 /// struct nk_vec2 nk_layout_space_to_local(struct nk_context*, struct nk_vec2);
@@ -25276,6 +25277,8 @@ nk_tooltipfv(struct nk_context *ctx, const char *fmt, va_list args)
 ///    - [yy]: Minor version with non-breaking API and library changes
 ///    - [zz]: Bug fix version with no direct changes to API
 ///
+/// - 2018/10/31 (4.00.2) - Added NK_KEYSTATE_BASED_INPUT to "fix" state based backends
+                            like GLFW without breaking key repeat behavior on event based.
 /// - 2018/04/01 (4.00.1) - Fixed calling `nk_convert` multiple time per single frame
 /// - 2018/04/01 (4.00.0) - BREAKING CHANGE: nk_draw_list_clear no longer tries to
 ///                         clear provided buffers. So make sure to either free

--- a/nuklear.h
+++ b/nuklear.h
@@ -18038,21 +18038,21 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
     panel_space = nk_layout_row_calculate_usable_space(&ctx->style, layout->type,
                                             layout->bounds.w, layout->row.columns);
 
-    #define FRAC(x) (x - (int)x) /* will be used to remove fookin gaps */
+    #define NK_FRAC(x) (x - (int)x) /* will be used to remove fookin gaps */
     /* calculate the width of one item inside the current layout space */
     switch (layout->row.type) {
     case NK_LAYOUT_DYNAMIC_FIXED: {
         /* scaling fixed size widgets item width */
         float w = NK_MAX(1.0f,panel_space) / (float)layout->row.columns;
         item_offset = (float)layout->row.index * w;
-        item_width = w + FRAC(item_offset);
+        item_width = w + NK_FRAC(item_offset);
         item_spacing = (float)layout->row.index * spacing.x;
     } break;
     case NK_LAYOUT_DYNAMIC_ROW: {
         /* scaling single ratio widget width */
         float w = layout->row.item_width * panel_space;
         item_offset = layout->row.item_offset;
-        item_width = w + FRAC(item_offset);
+        item_width = w + NK_FRAC(item_offset);
         item_spacing = 0;
 
         if (modify) {
@@ -18067,8 +18067,8 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
         bounds->x -= (float)*layout->offset_x;
         bounds->y = layout->at_y + (layout->row.height * layout->row.item.y);
         bounds->y -= (float)*layout->offset_y;
-        bounds->w = layout->bounds.w  * layout->row.item.w + FRAC(bounds->x);
-        bounds->h = layout->row.height * layout->row.item.h + FRAC(bounds->y);
+        bounds->w = layout->bounds.w  * layout->row.item.w + NK_FRAC(bounds->x);
+        bounds->h = layout->row.height * layout->row.item.h + NK_FRAC(bounds->y);
         return;
     }
     case NK_LAYOUT_DYNAMIC: {
@@ -18081,7 +18081,7 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
         w = (ratio * panel_space);
         item_spacing = (float)layout->row.index * spacing.x;
         item_offset = layout->row.item_offset;
-        item_width = w + FRAC(item_offset);
+        item_width = w + NK_FRAC(item_offset);
 
         if (modify) {
             layout->row.item_offset += w;
@@ -18127,11 +18127,11 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
         NK_ASSERT(layout->row.index < NK_MAX_LAYOUT_ROW_TEMPLATE_COLUMNS);
         w = layout->row.templates[layout->row.index];
         item_offset = layout->row.item_offset;
-        item_width = w + FRAC(item_offset);
+        item_width = w + NK_FRAC(item_offset);
         item_spacing = (float)layout->row.index * spacing.x;
         if (modify) layout->row.item_offset += w;
     } break;
-    #undef FRAC
+    #undef NK_FRAC
     default: NK_ASSERT(0); break;
     };
 

--- a/nuklear.h
+++ b/nuklear.h
@@ -7164,23 +7164,23 @@ nk_murmur_hash(const void * key, int len, nk_hash seed)
 {
     /* 32-Bit MurmurHash3: https://code.google.com/p/smhasher/wiki/MurmurHash3*/
     #define NK_ROTL(x,r) ((x) << (r) | ((x) >> (32 - r)))
-    union {const nk_uint *i; const nk_byte *b;} conv = {0};
-    const nk_byte *data = (const nk_byte*)key;
-    const int nblocks = len/4;
+
     nk_uint h1 = seed;
+    nk_uint k1;
+    const nk_byte *data = (const nk_byte*)key;
+    const nk_byte *keyptr = data;
+    const int bsize = sizeof(k1);
+    const int nblocks = len/4;
+
     const nk_uint c1 = 0xcc9e2d51;
     const nk_uint c2 = 0x1b873593;
     const nk_byte *tail;
-    const nk_uint *blocks;
-    nk_uint k1;
     int i;
 
     /* body */
     if (!key) return 0;
-    conv.b = (data + nblocks*4);
-    blocks = (const nk_uint*)conv.i;
-    for (i = -nblocks; i; ++i) {
-        k1 = blocks[i];
+    for (i = 0; i < nblocks; ++i, keyptr += bsize) {
+        memcpy(&k1, keyptr, bsize);
         k1 *= c1;
         k1 = NK_ROTL(k1,15);
         k1 *= c2;
@@ -7194,15 +7194,15 @@ nk_murmur_hash(const void * key, int len, nk_hash seed)
     tail = (const nk_byte*)(data + nblocks*4);
     k1 = 0;
     switch (len & 3) {
-    case 3: k1 ^= (nk_uint)(tail[2] << 16); /* fallthrough */
-    case 2: k1 ^= (nk_uint)(tail[1] << 8u); /* fallthrough */
-    case 1: k1 ^= tail[0];
+        case 3: k1 ^= (nk_uint)(tail[2] << 16); /* fallthrough */
+        case 2: k1 ^= (nk_uint)(tail[1] << 8u); /* fallthrough */
+        case 1: k1 ^= tail[0];
             k1 *= c1;
             k1 = NK_ROTL(k1,15);
             k1 *= c2;
             h1 ^= k1;
             break;
-    default: break;
+        default: break;
     }
 
     /* finalization */

--- a/nuklear.h
+++ b/nuklear.h
@@ -18038,22 +18038,25 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
     panel_space = nk_layout_row_calculate_usable_space(&ctx->style, layout->type,
                                             layout->bounds.w, layout->row.columns);
 
+    #define FRAC(x) (x - (int)x) /* will be used to remove fookin gaps */
     /* calculate the width of one item inside the current layout space */
     switch (layout->row.type) {
     case NK_LAYOUT_DYNAMIC_FIXED: {
         /* scaling fixed size widgets item width */
-        item_width = NK_MAX(1.0f,panel_space) / (float)layout->row.columns;
-        item_offset = (float)layout->row.index * item_width;
+        float w = NK_MAX(1.0f,panel_space) / (float)layout->row.columns;
+        item_offset = (float)layout->row.index * w;
+        item_width = w + FRAC(item_offset);
         item_spacing = (float)layout->row.index * spacing.x;
     } break;
     case NK_LAYOUT_DYNAMIC_ROW: {
         /* scaling single ratio widget width */
-        item_width = layout->row.item_width * panel_space;
+        float w = layout->row.item_width * panel_space;
         item_offset = layout->row.item_offset;
+        item_width = w + FRAC(item_offset);
         item_spacing = 0;
 
         if (modify) {
-            layout->row.item_offset += item_width + spacing.x;
+            layout->row.item_offset += w + spacing.x;
             layout->row.filled += layout->row.item_width;
             layout->row.index = 0;
         }
@@ -18064,23 +18067,24 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
         bounds->x -= (float)*layout->offset_x;
         bounds->y = layout->at_y + (layout->row.height * layout->row.item.y);
         bounds->y -= (float)*layout->offset_y;
-        bounds->w = layout->bounds.w  * layout->row.item.w;
-        bounds->h = layout->row.height * layout->row.item.h;
+        bounds->w = layout->bounds.w  * layout->row.item.w + FRAC(bounds->x);
+        bounds->h = layout->row.height * layout->row.item.h + FRAC(bounds->y);
         return;
     }
     case NK_LAYOUT_DYNAMIC: {
         /* scaling arrays of panel width ratios for every widget */
-        float ratio;
+        float ratio, w;
         NK_ASSERT(layout->row.ratio);
         ratio = (layout->row.ratio[layout->row.index] < 0) ?
             layout->row.item_width : layout->row.ratio[layout->row.index];
 
+        w = (ratio * panel_space);
         item_spacing = (float)layout->row.index * spacing.x;
-        item_width = (ratio * panel_space);
         item_offset = layout->row.item_offset;
+        item_width = w + FRAC(item_offset);
 
         if (modify) {
-            layout->row.item_offset += item_width;
+            layout->row.item_offset += w;
             layout->row.filled += ratio;
         }
     } break;
@@ -18118,13 +18122,16 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
     } break;
     case NK_LAYOUT_TEMPLATE: {
         /* stretchy row layout with combined dynamic/static widget width*/
+        float w;
         NK_ASSERT(layout->row.index < layout->row.columns);
         NK_ASSERT(layout->row.index < NK_MAX_LAYOUT_ROW_TEMPLATE_COLUMNS);
-        item_width = layout->row.templates[layout->row.index];
+        w = layout->row.templates[layout->row.index];
         item_offset = layout->row.item_offset;
+        item_width = w + FRAC(item_offset);
         item_spacing = (float)layout->row.index * spacing.x;
-        if (modify) layout->row.item_offset += item_width;
+        if (modify) layout->row.item_offset += w;
     } break;
+    #undef FRAC
     default: NK_ASSERT(0); break;
     };
 

--- a/nuklear.h
+++ b/nuklear.h
@@ -7169,6 +7169,7 @@ nk_murmur_hash(const void * key, int len, nk_hash seed)
     nk_uint k1;
     const nk_byte *data = (const nk_byte*)key;
     const nk_byte *keyptr = data;
+    nk_byte *k1ptr;
     const int bsize = sizeof(k1);
     const int nblocks = len/4;
 
@@ -7180,7 +7181,12 @@ nk_murmur_hash(const void * key, int len, nk_hash seed)
     /* body */
     if (!key) return 0;
     for (i = 0; i < nblocks; ++i, keyptr += bsize) {
-        memcpy(&k1, keyptr, bsize);
+        k1ptr = (nk_byte*)&k1;
+        k1ptr[0] = keyptr[0];
+        k1ptr[1] = keyptr[1];
+        k1ptr[2] = keyptr[2];
+        k1ptr[3] = keyptr[3];
+
         k1 *= c1;
         k1 = NK_ROTL(k1,15);
         k1 *= c2;

--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -8,6 +8,8 @@
 ///    - [yy]: Minor version with non-breaking API and library changes
 ///    - [zz]: Bug fix version with no direct changes to API
 ///
+/// - 2018/10/31 (4.00.2) - Added NK_KEYSTATE_BASED_INPUT to "fix" state based backends
+                            like GLFW without breaking key repeat behavior on event based.
 /// - 2018/04/01 (4.00.1) - Fixed calling `nk_convert` multiple time per single frame
 /// - 2018/04/01 (4.00.0) - BREAKING CHANGE: nk_draw_list_clear no longer tries to
 ///                         clear provided buffers. So make sure to either free

--- a/src/HEADER
+++ b/src/HEADER
@@ -105,6 +105,7 @@
 /// NK_BUTTON_TRIGGER_ON_RELEASE    | Different platforms require button clicks occurring either on buttons being pressed (up to down) or released (down to up). By default this library will react on buttons being pressed, but if you define this it will only trigger if a button is released.
 /// NK_ZERO_COMMAND_MEMORY          | Defining this will zero out memory for each drawing command added to a drawing queue (inside nk_command_buffer_push). Zeroing command memory is very useful for fast checking (using memcmp) if command buffers are equal and avoid drawing frames when nothing on screen has changed since previous frame.
 /// NK_UINT_DRAW_INDEX              | Defining this will set the size of vertex index elements when using NK_VERTEX_BUFFER_OUTPUT to 32bit instead of the default of 16bit
+/// NK_KEYSTATE_BASED_INPUT         | Define this if your backend uses key state for each frame rather than key press/release events
 ///
 /// !!! WARNING
 ///     The following flags will pull in the standard C library:

--- a/src/nuklear.h
+++ b/src/nuklear.h
@@ -1295,7 +1295,7 @@ NK_API void nk_end(struct nk_context *ctx);
 /// Finds and returns a window from passed name
 ///
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
-/// void nk_end(struct nk_context *ctx);
+/// struct nk_window *nk_window_find(struct nk_context *ctx, const char *name);
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ///
 /// Parameter   | Description

--- a/src/nuklear_input.c
+++ b/src/nuklear_input.c
@@ -60,8 +60,12 @@ nk_input_key(struct nk_context *ctx, enum nk_keys key, int down)
     NK_ASSERT(ctx);
     if (!ctx) return;
     in = &ctx->input;
+#ifdef NK_KEYSTATE_BASED_INPUT
     if (in->keyboard.keys[key].down != down)
         in->keyboard.keys[key].clicked++;
+#else
+    in->keyboard.keys[key].clicked++;
+#endif
     in->keyboard.keys[key].down = down;
 }
 NK_API void

--- a/src/nuklear_layout.c
+++ b/src/nuklear_layout.c
@@ -605,22 +605,25 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
     panel_space = nk_layout_row_calculate_usable_space(&ctx->style, layout->type,
                                             layout->bounds.w, layout->row.columns);
 
+    #define FRAC(x) (x - (int)x) /* will be used to remove fookin gaps */
     /* calculate the width of one item inside the current layout space */
     switch (layout->row.type) {
     case NK_LAYOUT_DYNAMIC_FIXED: {
         /* scaling fixed size widgets item width */
-        item_width = NK_MAX(1.0f,panel_space) / (float)layout->row.columns;
-        item_offset = (float)layout->row.index * item_width;
+        float w = NK_MAX(1.0f,panel_space) / (float)layout->row.columns;
+        item_offset = (float)layout->row.index * w;
+        item_width = w + FRAC(item_offset);
         item_spacing = (float)layout->row.index * spacing.x;
     } break;
     case NK_LAYOUT_DYNAMIC_ROW: {
         /* scaling single ratio widget width */
-        item_width = layout->row.item_width * panel_space;
+        float w = layout->row.item_width * panel_space;
         item_offset = layout->row.item_offset;
+        item_width = w + FRAC(item_offset);
         item_spacing = 0;
 
         if (modify) {
-            layout->row.item_offset += item_width + spacing.x;
+            layout->row.item_offset += w + spacing.x;
             layout->row.filled += layout->row.item_width;
             layout->row.index = 0;
         }
@@ -631,23 +634,24 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
         bounds->x -= (float)*layout->offset_x;
         bounds->y = layout->at_y + (layout->row.height * layout->row.item.y);
         bounds->y -= (float)*layout->offset_y;
-        bounds->w = layout->bounds.w  * layout->row.item.w;
-        bounds->h = layout->row.height * layout->row.item.h;
+        bounds->w = layout->bounds.w  * layout->row.item.w + FRAC(bounds->x);
+        bounds->h = layout->row.height * layout->row.item.h + FRAC(bounds->y);
         return;
     }
     case NK_LAYOUT_DYNAMIC: {
         /* scaling arrays of panel width ratios for every widget */
-        float ratio;
+        float ratio, w;
         NK_ASSERT(layout->row.ratio);
         ratio = (layout->row.ratio[layout->row.index] < 0) ?
             layout->row.item_width : layout->row.ratio[layout->row.index];
 
+        w = (ratio * panel_space);
         item_spacing = (float)layout->row.index * spacing.x;
-        item_width = (ratio * panel_space);
         item_offset = layout->row.item_offset;
+        item_width = w + FRAC(item_offset);
 
         if (modify) {
-            layout->row.item_offset += item_width;
+            layout->row.item_offset += w;
             layout->row.filled += ratio;
         }
     } break;
@@ -685,13 +689,16 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
     } break;
     case NK_LAYOUT_TEMPLATE: {
         /* stretchy row layout with combined dynamic/static widget width*/
+        float w;
         NK_ASSERT(layout->row.index < layout->row.columns);
         NK_ASSERT(layout->row.index < NK_MAX_LAYOUT_ROW_TEMPLATE_COLUMNS);
-        item_width = layout->row.templates[layout->row.index];
+        w = layout->row.templates[layout->row.index];
         item_offset = layout->row.item_offset;
+        item_width = w + FRAC(item_offset);
         item_spacing = (float)layout->row.index * spacing.x;
-        if (modify) layout->row.item_offset += item_width;
+        if (modify) layout->row.item_offset += w;
     } break;
+    #undef FRAC
     default: NK_ASSERT(0); break;
     };
 

--- a/src/nuklear_layout.c
+++ b/src/nuklear_layout.c
@@ -605,21 +605,21 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
     panel_space = nk_layout_row_calculate_usable_space(&ctx->style, layout->type,
                                             layout->bounds.w, layout->row.columns);
 
-    #define FRAC(x) (x - (int)x) /* will be used to remove fookin gaps */
+    #define NK_FRAC(x) (x - (int)x) /* will be used to remove fookin gaps */
     /* calculate the width of one item inside the current layout space */
     switch (layout->row.type) {
     case NK_LAYOUT_DYNAMIC_FIXED: {
         /* scaling fixed size widgets item width */
         float w = NK_MAX(1.0f,panel_space) / (float)layout->row.columns;
         item_offset = (float)layout->row.index * w;
-        item_width = w + FRAC(item_offset);
+        item_width = w + NK_FRAC(item_offset);
         item_spacing = (float)layout->row.index * spacing.x;
     } break;
     case NK_LAYOUT_DYNAMIC_ROW: {
         /* scaling single ratio widget width */
         float w = layout->row.item_width * panel_space;
         item_offset = layout->row.item_offset;
-        item_width = w + FRAC(item_offset);
+        item_width = w + NK_FRAC(item_offset);
         item_spacing = 0;
 
         if (modify) {
@@ -634,8 +634,8 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
         bounds->x -= (float)*layout->offset_x;
         bounds->y = layout->at_y + (layout->row.height * layout->row.item.y);
         bounds->y -= (float)*layout->offset_y;
-        bounds->w = layout->bounds.w  * layout->row.item.w + FRAC(bounds->x);
-        bounds->h = layout->row.height * layout->row.item.h + FRAC(bounds->y);
+        bounds->w = layout->bounds.w  * layout->row.item.w + NK_FRAC(bounds->x);
+        bounds->h = layout->row.height * layout->row.item.h + NK_FRAC(bounds->y);
         return;
     }
     case NK_LAYOUT_DYNAMIC: {
@@ -648,7 +648,7 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
         w = (ratio * panel_space);
         item_spacing = (float)layout->row.index * spacing.x;
         item_offset = layout->row.item_offset;
-        item_width = w + FRAC(item_offset);
+        item_width = w + NK_FRAC(item_offset);
 
         if (modify) {
             layout->row.item_offset += w;
@@ -694,11 +694,11 @@ nk_layout_widget_space(struct nk_rect *bounds, const struct nk_context *ctx,
         NK_ASSERT(layout->row.index < NK_MAX_LAYOUT_ROW_TEMPLATE_COLUMNS);
         w = layout->row.templates[layout->row.index];
         item_offset = layout->row.item_offset;
-        item_width = w + FRAC(item_offset);
+        item_width = w + NK_FRAC(item_offset);
         item_spacing = (float)layout->row.index * spacing.x;
         if (modify) layout->row.item_offset += w;
     } break;
-    #undef FRAC
+    #undef NK_FRAC
     default: NK_ASSERT(0); break;
     };
 

--- a/src/nuklear_util.c
+++ b/src/nuklear_util.c
@@ -919,6 +919,7 @@ nk_murmur_hash(const void * key, int len, nk_hash seed)
     nk_uint k1;
     const nk_byte *data = (const nk_byte*)key;
     const nk_byte *keyptr = data;
+    nk_byte *k1ptr;
     const int bsize = sizeof(k1);
     const int nblocks = len/4;
 
@@ -930,7 +931,12 @@ nk_murmur_hash(const void * key, int len, nk_hash seed)
     /* body */
     if (!key) return 0;
     for (i = 0; i < nblocks; ++i, keyptr += bsize) {
-        memcpy(&k1, keyptr, bsize);
+        k1ptr = (nk_byte*)&k1;
+        k1ptr[0] = keyptr[0];
+        k1ptr[1] = keyptr[1];
+        k1ptr[2] = keyptr[2];
+        k1ptr[3] = keyptr[3];
+
         k1 *= c1;
         k1 = NK_ROTL(k1,15);
         k1 *= c2;

--- a/src/nuklear_util.c
+++ b/src/nuklear_util.c
@@ -914,23 +914,23 @@ nk_murmur_hash(const void * key, int len, nk_hash seed)
 {
     /* 32-Bit MurmurHash3: https://code.google.com/p/smhasher/wiki/MurmurHash3*/
     #define NK_ROTL(x,r) ((x) << (r) | ((x) >> (32 - r)))
-    union {const nk_uint *i; const nk_byte *b;} conv = {0};
-    const nk_byte *data = (const nk_byte*)key;
-    const int nblocks = len/4;
+
     nk_uint h1 = seed;
+    nk_uint k1;
+    const nk_byte *data = (const nk_byte*)key;
+    const nk_byte *keyptr = data;
+    const int bsize = sizeof(k1);
+    const int nblocks = len/4;
+
     const nk_uint c1 = 0xcc9e2d51;
     const nk_uint c2 = 0x1b873593;
     const nk_byte *tail;
-    const nk_uint *blocks;
-    nk_uint k1;
     int i;
 
     /* body */
     if (!key) return 0;
-    conv.b = (data + nblocks*4);
-    blocks = (const nk_uint*)conv.i;
-    for (i = -nblocks; i; ++i) {
-        k1 = blocks[i];
+    for (i = 0; i < nblocks; ++i, keyptr += bsize) {
+        memcpy(&k1, keyptr, bsize);
         k1 *= c1;
         k1 = NK_ROTL(k1,15);
         k1 *= c2;
@@ -944,15 +944,15 @@ nk_murmur_hash(const void * key, int len, nk_hash seed)
     tail = (const nk_byte*)(data + nblocks*4);
     k1 = 0;
     switch (len & 3) {
-    case 3: k1 ^= (nk_uint)(tail[2] << 16); /* fallthrough */
-    case 2: k1 ^= (nk_uint)(tail[1] << 8u); /* fallthrough */
-    case 1: k1 ^= tail[0];
+        case 3: k1 ^= (nk_uint)(tail[2] << 16); /* fallthrough */
+        case 2: k1 ^= (nk_uint)(tail[1] << 8u); /* fallthrough */
+        case 1: k1 ^= tail[0];
             k1 *= c1;
             k1 = NK_ROTL(k1,15);
             k1 *= c2;
             h1 ^= k1;
             break;
-    default: break;
+        default: break;
     }
 
     /* finalization */


### PR DESCRIPTION
*My apologies, I've apparently screwed up this pull request... not sure how to undo it.*

The x11_rawfb demo fails to redraw the last column of the screen. This is due to `nk_rawfb_stroke_line()` subtracting 1 from the scissors width argument which prevents a line to be stroked in that last column. Drawing routines that don't rely on `_stroke_line()` can still draw to the last column, but `nk_rawfb_clear()` won't, resulting in past frame's cruft remaining on the screen. 