### PR TITLE
Implementing missing x11_rawfb features colored text and multi-color-rect

### DIFF
--- a/demo/x11_rawfb/main.c
+++ b/demo/x11_rawfb/main.c
@@ -189,10 +189,10 @@ main(void)
     if (!rawfb) running = 0;
 
     #ifdef INCLUDE_STYLE
-    /*set_style(ctx, THEME_WHITE);*/
-    /*set_style(ctx, THEME_RED);*/
-    /*set_style(ctx, THEME_BLUE);*/
-    /*set_style(ctx, THEME_DARK);*/
+    /*set_style(&rawfb->ctx, THEME_WHITE);*/
+    /*set_style(&rawfb->ctx, THEME_RED);*/
+    /*set_style(&rawfb->ctx, THEME_BLUE);*/
+    /*set_style(&rawfb->ctx, THEME_DARK);*/
     #endif
 
     while (running) {

--- a/demo/x11_rawfb/main.c
+++ b/demo/x11_rawfb/main.c
@@ -35,7 +35,7 @@
 #include <unistd.h>
 #include <time.h>
 
-#define RAWFB_RGBX_8888
+#define RAWFB_XRGB_8888
 #define NK_INCLUDE_FIXED_TYPES
 #define NK_INCLUDE_STANDARD_IO
 #define NK_INCLUDE_STANDARD_VARARGS

--- a/demo/x11_rawfb/nuklear_rawfb.h
+++ b/demo/x11_rawfb/nuklear_rawfb.h
@@ -73,12 +73,12 @@ static unsigned int
 nk_rawfb_color2int(const struct nk_color *c)
 {
     unsigned int res = 0;
-#if defined(RAWFB_RGBX_8888)
+#if defined(RAWFB_RGBX_8888) && !defined(RAWFB_XRGB_8888)
     res |= c->r << 24;
     res |= c->g << 16;
     res |= c->b << 8;
     res |= c->a;
-#elif defined(RAWFB_XRGB_8888)
+#elif defined(RAWFB_XRGB_8888) && !defined(RAWFB_RGBX_8888)
     res |= c->a << 24;
     res |= c->r << 16;
     res |= c->g << 8;
@@ -93,12 +93,12 @@ static struct nk_color
 nk_rawfb_int2color(const unsigned int i)
 {
     struct nk_color col;
-#if defined(RAWFB_RGBX_8888)
+#if defined(RAWFB_RGBX_8888) && !defined(RAWFB_XRGB_8888)
     col.r = (i >> 24) & 0xff;
     col.g = (i >> 16) & 0xff;
     col.b = (i >> 8) & 0xff;
     col.a = (i >> 0) & 0xff;
-#elif defined(RAWFB_XRGB_8888)
+#elif defined(RAWFB_XRGB_8888) && !defined(RAWFB_RGBX_8888)
     col.a = (i >> 24) & 0xff;
     col.r = (i >> 16) & 0xff;
     col.g = (i >> 8) & 0xff;

--- a/demo/x11_rawfb/nuklear_rawfb.h
+++ b/demo/x11_rawfb/nuklear_rawfb.h
@@ -70,19 +70,19 @@ struct rawfb_context {
 #endif
 
 static unsigned int
-nk_rawfb_color2int(const struct nk_color *c)
+nk_rawfb_color2int(const struct nk_color c)
 {
     unsigned int res = 0;
 #if defined(RAWFB_RGBX_8888) && !defined(RAWFB_XRGB_8888)
-    res |= c->r << 24;
-    res |= c->g << 16;
-    res |= c->b << 8;
-    res |= c->a;
+    res |= c.r << 24;
+    res |= c.g << 16;
+    res |= c.b << 8;
+    res |= c.a;
 #elif defined(RAWFB_XRGB_8888) && !defined(RAWFB_RGBX_8888)
-    res |= c->a << 24;
-    res |= c->r << 16;
-    res |= c->g << 8;
-    res |= c->b << 0;
+    res |= c.a << 24;
+    res |= c.r << 16;
+    res |= c.g << 8;
+    res |= c.b << 0;
 #else
 #error Define one of RAWFB_RGBX_8888 , RAWFB_XRGB_8888
 #endif
@@ -113,7 +113,7 @@ static void
 nk_rawfb_ctx_setpixel(const struct rawfb_context *rawfb,
     const short x0, const short y0, const struct nk_color col)
 {
-    unsigned int c = nk_rawfb_color2int(&col);
+    unsigned int c = nk_rawfb_color2int(col);
     unsigned char *pixels = rawfb->fb.pixels;
     unsigned int *ptr;
 
@@ -144,7 +144,7 @@ nk_rawfb_line_horizontal(const struct rawfb_context *rawfb,
 
     n = x1 - x0;
     for (i = 0; i < sizeof(c) / sizeof(c[0]); i++)
-        c[i] = nk_rawfb_color2int(&col);
+        c[i] = nk_rawfb_color2int(col);
 
     while (n > 16) {
         memcpy((void *)ptr, c, sizeof(c));
@@ -157,7 +157,7 @@ static void
 nk_rawfb_img_setpixel(const struct rawfb_image *img,
     const int x0, const int y0, const struct nk_color col)
 {
-    unsigned int c = nk_rawfb_color2int(&col);
+    unsigned int c = nk_rawfb_color2int(col);
     unsigned char *ptr;
     unsigned int *pixel;
     NK_ASSERT(img);

--- a/demo/x11_rawfb/nuklear_rawfb.h
+++ b/demo/x11_rawfb/nuklear_rawfb.h
@@ -537,6 +537,81 @@ nk_rawfb_fill_rect(const struct rawfb_context *rawfb,
     }
 }
 
+NK_API void
+nk_rawfb_draw_rect_multi_color(const struct rawfb_context *rawfb,
+    const short x, const short y, const short w, const short h, struct nk_color tl,
+    struct nk_color tr, struct nk_color br, struct nk_color bl)
+{
+    int i, j;
+    struct nk_color *edge_buf;
+    struct nk_color *edge_t;
+    struct nk_color *edge_b;
+    struct nk_color *edge_l;
+    struct nk_color *edge_r;
+    struct nk_color pixel;
+
+    edge_buf = malloc(((2*w) + (2*h)) * sizeof(struct nk_color));
+    if (edge_buf == NULL)
+	return;
+
+    edge_t = edge_buf;
+    edge_b = edge_buf + w;
+    edge_l = edge_buf + (w*2);
+    edge_r = edge_buf + (w*2) + h;
+
+    /* Top and bottom edge gradients */
+    for (i=0; i<w; i++)
+    {
+	edge_t[i].r = (((((float)tr.r - tl.r)/(w-1))*i) + 0.5) + tl.r;
+	edge_t[i].g = (((((float)tr.g - tl.g)/(w-1))*i) + 0.5) + tl.g;
+	edge_t[i].b = (((((float)tr.b - tl.b)/(w-1))*i) + 0.5) + tl.b;
+	edge_t[i].a = (((((float)tr.a - tl.a)/(w-1))*i) + 0.5) + tl.a;
+
+	edge_b[i].r = (((((float)br.r - bl.r)/(w-1))*i) + 0.5) + bl.r;
+	edge_b[i].g = (((((float)br.g - bl.g)/(w-1))*i) + 0.5) + bl.g;
+	edge_b[i].b = (((((float)br.b - bl.b)/(w-1))*i) + 0.5) + bl.b;
+	edge_b[i].a = (((((float)br.a - bl.a)/(w-1))*i) + 0.5) + bl.a;
+    }
+
+    /* Left and right edge gradients */
+    for (i=0; i<h; i++)
+    {
+	edge_l[i].r = (((((float)bl.r - tl.r)/(h-1))*i) + 0.5) + tl.r;
+	edge_l[i].g = (((((float)bl.g - tl.g)/(h-1))*i) + 0.5) + tl.g;
+	edge_l[i].b = (((((float)bl.b - tl.b)/(h-1))*i) + 0.5) + tl.b;
+	edge_l[i].a = (((((float)bl.a - tl.a)/(h-1))*i) + 0.5) + tl.a;
+
+	edge_r[i].r = (((((float)br.r - tr.r)/(h-1))*i) + 0.5) + tr.r;
+	edge_r[i].g = (((((float)br.g - tr.g)/(h-1))*i) + 0.5) + tr.g;
+	edge_r[i].b = (((((float)br.b - tr.b)/(h-1))*i) + 0.5) + tr.b;
+	edge_r[i].a = (((((float)br.a - tr.a)/(h-1))*i) + 0.5) + tr.a;
+    }
+
+    for (i=0; i<h; i++) {
+	for (j=0; j<w; j++) {
+	    if (i==0) {
+		nk_image_blendpixel(&rawfb->fb, x+j, y+i, edge_t[j]);
+	    } else if (i==h-1) {
+		nk_image_blendpixel(&rawfb->fb, x+j, y+i, edge_b[j]);
+	    } else {
+		if (j==0) {
+		    nk_image_blendpixel(&rawfb->fb, x+j, y+i, edge_l[i]);
+		} else if (j==w-1) {
+		    nk_image_blendpixel(&rawfb->fb, x+j, y+i, edge_r[i]);
+		} else {
+		    pixel.r = (((((float)edge_r[i].r - edge_l[i].r)/(w-1))*j) + 0.5) + edge_l[i].r;
+		    pixel.g = (((((float)edge_r[i].g - edge_l[i].g)/(w-1))*j) + 0.5) + edge_l[i].g;
+		    pixel.b = (((((float)edge_r[i].b - edge_l[i].b)/(w-1))*j) + 0.5) + edge_l[i].b;
+		    pixel.a = (((((float)edge_r[i].a - edge_l[i].a)/(w-1))*j) + 0.5) + edge_l[i].a;
+		    nk_image_blendpixel(&rawfb->fb, x+j, y+i, pixel);
+		}
+	    }
+	}
+    }
+
+    free(edge_buf);
+}
+
 static void
 nk_rawfb_fill_triangle(const struct rawfb_context *rawfb,
     const short x0, const short y0, const short x1, const short y1,
@@ -976,7 +1051,10 @@ nk_rawfb_render(const struct rawfb_context *rawfb,
             nk_rawfb_stroke_curve(rawfb, q->begin, q->ctrl[0], q->ctrl[1],
                 q->end, 22, q->line_thickness, q->color);
         } break;
-        case NK_COMMAND_RECT_MULTI_COLOR:
+        case NK_COMMAND_RECT_MULTI_COLOR: {
+	    const struct nk_command_rect_multi_color *q = (const struct nk_command_rect_multi_color *)cmd;
+	    nk_rawfb_draw_rect_multi_color(rawfb, q->x, q->y, q->w, q->h, q->left, q->top, q->right, q->bottom);
+	} break;
         case NK_COMMAND_IMAGE: {
             const struct nk_command_image *q = (const struct nk_command_image *)cmd;
             nk_rawfb_drawimage(rawfb, q->x, q->y, q->w, q->h, &q->img, &q->col);

--- a/demo/x11_rawfb/nuklear_rawfb.h
+++ b/demo/x11_rawfb/nuklear_rawfb.h
@@ -870,7 +870,6 @@ nk_rawfb_stretch_image(const struct rawfb_image *dst,
                     continue;
             }
             col = nk_image_getpixel(src, (int)xoff, (int) yoff);
-	    /* This assumes the font atlas uses transparent black for non-glyph pixels */
 	    if (col.r || col.g || col.b)
 	    {
 		col.r = fg->r;


### PR DESCRIPTION
This implements rendering of colored text for the x11_rawfb demo and an implementation of rendering multi-colored rectangles. The latter is used by the color picker widget which currently doesn't display properly. 

Both of these changes make use of the `nk_image_blendpixel()` routine which I modified to swap the `r` and `b` bytes of the nk_color. I'm still not sure where these are getting swizzled in the first place, but this change makes it so everything renders in the requested color. If anyone has any insight into where the 'real' fix for this is, I can make the appropriate change. 