### PR TITLE
Fix drawing to last column of screen for x11_rawfb

### DIFF
--- a/demo/x11_rawfb/nuklear_rawfb.h
+++ b/demo/x11_rawfb/nuklear_rawfb.h
@@ -218,8 +218,8 @@ nk_rawfb_stroke_line(const struct rawfb_context *rawfb,
             x1 = x0;
             x0 = tmp;
         }
-        x1 = MIN(rawfb->scissors.w - 1, x1);
-        x0 = MIN(rawfb->scissors.w - 1, x0);
+        x1 = MIN(rawfb->scissors.w, x1);
+        x0 = MIN(rawfb->scissors.w, x0);
         x1 = MAX(rawfb->scissors.x, x1);
         x0 = MAX(rawfb->scissors.x, x0);
         nk_rawfb_line_horizontal(rawfb, x0, y0, x1, col);


### PR DESCRIPTION
The routine `nk_rawfb_stroke_line()` was incorrectly clamping the allowable x coordinates to be `scissors.w - 1` instead of just `scissors.w`. This had the effect of preventing `_stroke_line()` from drawing to the last column on the screen. Other drawing methods could correctly draw to the last column, but since `nk_rawfb_clear()` used `_stroke_line()` the cruft in that last column from previous frames was never getting cleared. 