### PR TITLE
Implement missing features and make multiple fixes for x11_rawfb

### DIFF
--- a/demo/x11_rawfb/Makefile
+++ b/demo/x11_rawfb/Makefile
@@ -2,7 +2,7 @@
 BIN = zahnrad
 
 # Flags
-CFLAGS += -std=c89 -pedantic -O2 -Wunused -DRAWFB_XRGB_8888
+CFLAGS += -std=c89 -pedantic -O2 -Wunused
 
 SRC = main.c
 OBJ = $(SRC:.c=.o)

--- a/demo/x11_rawfb/main.c
+++ b/demo/x11_rawfb/main.c
@@ -189,10 +189,10 @@ main(void)
     if (!rawfb) running = 0;
 
     #ifdef INCLUDE_STYLE
-    /*set_style(ctx, THEME_WHITE);*/
-    /*set_style(ctx, THEME_RED);*/
-    /*set_style(ctx, THEME_BLUE);*/
-    /*set_style(ctx, THEME_DARK);*/
+    /*set_style(&rawfb->ctx, THEME_WHITE);*/
+    /*set_style(&rawfb->ctx, THEME_RED);*/
+    /*set_style(&rawfb->ctx, THEME_BLUE);*/
+    /*set_style(&rawfb->ctx, THEME_DARK);*/
     #endif
 
     while (running) {

--- a/demo/x11_rawfb/main.c
+++ b/demo/x11_rawfb/main.c
@@ -35,7 +35,6 @@
 #include <unistd.h>
 #include <time.h>
 
-#define RAWFB_XRGB_8888
 #define NK_INCLUDE_FIXED_TYPES
 #define NK_INCLUDE_STANDARD_IO
 #define NK_INCLUDE_STANDARD_VARARGS
@@ -152,6 +151,7 @@ main(void)
     XWindow xw;
     struct rawfb_context *rawfb;
     void *fb = NULL;
+    rawfb_pl pl;
     unsigned char tex_scratch[512 * 512];
 
     /* X11 */
@@ -180,12 +180,12 @@ main(void)
     xw.height = (unsigned int)xw.attr.height;
 
     /* Framebuffer emulator */
-    status = nk_xlib_init(xw.dpy, xw.vis, xw.screen, xw.win, xw.width, xw.height, &fb);
+    status = nk_xlib_init(xw.dpy, xw.vis, xw.screen, xw.win, xw.width, xw.height, &fb, &pl);
     if (!status || !fb)
         return 0;
 
     /* GUI */
-    rawfb = nk_rawfb_init(fb, tex_scratch, xw.width, xw.height, xw.width * 4);
+    rawfb = nk_rawfb_init(fb, tex_scratch, xw.width, xw.height, xw.width * 4, pl);
     if (!rawfb) running = 0;
 
     #ifdef INCLUDE_STYLE

--- a/demo/x11_rawfb/main.c
+++ b/demo/x11_rawfb/main.c
@@ -35,7 +35,7 @@
 #include <unistd.h>
 #include <time.h>
 
-#define RAWFB_RGBX_8888
+#define RAWFB_XRGB_8888
 #define NK_INCLUDE_FIXED_TYPES
 #define NK_INCLUDE_STANDARD_IO
 #define NK_INCLUDE_STANDARD_VARARGS


### PR DESCRIPTION
This is effectively the same as PR #847 with a cleaned up commit history and the addition of making the pixel layout determined at runtime instead of relying on compile time decisions. This is done by storing the pixel layout (as an enum) in the `struct rawfb_image`. This is determined by reading the appropriate masks out of the XImage in `nk_xlib_init()` and setting the pixel layout appropriately. Currently only supports XRGB and RGBX. 

Also fixed up some potential null dereferencing issues on error return paths. 

The rest of the fixes are (see #847  for details):
- implementing multi color rectangle rendering
- implementing foreground text color rendering
- Cleanup and fixes of get/set pixel routines
- Fix arguments to `set_style()` examples. 
