### PR TITLE
Fix nits (see PR #851) to clean up x11_rawfb

### DIFF
--- a/demo/x11_rawfb/nuklear_xlib.h
+++ b/demo/x11_rawfb/nuklear_xlib.h
@@ -148,7 +148,7 @@ nk_xlib_init(Display *dpy, Visual *vis, int screen, Window root,
 	*pl = PIXEL_LAYOUT_RGBX_8888;
     }
     else {
-	printf("Unrecognized pixel layout.\n");
+	perror("nk_xlib_init(): Unrecognized pixel layout.\n");
 	return 0;
     }
 


### PR DESCRIPTION
General cleanup for x11_rawfb to simplify pointer assignments, add function names to error messages, and remove unnecessary bit shifting. 

I suppose one could use some sort of \_\_FUNCTION\_\_ or \_\_func\_\_ for function names in error messages but I don't remember if that's c89 compliant or what compilers other than gcc will do with that. If someone wants a generic error handler macro/function that incorporates such a thing, I'll leave that to others more knowledgable. 