### PR TITLE
Pointer size for MinGW 64Bit / Castings

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -370,7 +370,7 @@ extern "C" {
       #define NK_SIZE_TYPE unsigned __int32
     #elif defined(__GNUC__) || defined(__clang__)
       #if defined(__x86_64__) || defined(__ppc64__)
-        #define NK_SIZE_TYPE unsigned long
+        #define NK_SIZE_TYPE unsigned long long
       #else
         #define NK_SIZE_TYPE unsigned int
       #endif
@@ -385,7 +385,7 @@ extern "C" {
       #define NK_POINTER_TYPE unsigned __int32
     #elif defined(__GNUC__) || defined(__clang__)
       #if defined(__x86_64__) || defined(__ppc64__)
-        #define NK_POINTER_TYPE unsigned long
+        #define NK_POINTER_TYPE unsigned long long
       #else
         #define NK_POINTER_TYPE unsigned int
       #endif


### PR DESCRIPTION
The pointer size of the MinGW 64Bit pointer is "unsinged long long". 
Is this also true for GCC 64Bit on Linux?

There are a lot of compiler warnings at compile time for the "nuklear_gdi.h". 
I have added some castings.
For the GNUC compiler I added the pragmas to suppress warnings from newer C++ standards.