### PR TITLE
Added loop detection to the context draw command list

### DIFF
--- a/src/nuklear.h
+++ b/src/nuklear.h
@@ -5386,6 +5386,7 @@ struct nk_context {
     struct nk_page_element *freelist;
     unsigned int count;
     unsigned int seq;
+	const struct nk_command* loop;
 };
 
 /* ==============================================================


### PR DESCRIPTION
I found out that sometimes the contextual menus can freeze nuklear, this happen with both `nk_contextual_xxx` and `nk_menu_xxx`. Searching for the origin of the freeze I found out it's a loop inside the context draw command list: one command in the list reference a previous already processed one, causing a loop.
I added a simple loop detection and suppression to `nk__begin` and `nk__next` (the functions that should be used on the command list), that way any loop is quickly detected and fixed.
I did not investigate why this happen with contextual menus to begin with because I do not have time, but I can implement a debug function to get informations about a detected loop if needed.
 