### PR TITLE
Issue #896: Allow re-baking without clearing the baker.

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -12895,6 +12895,7 @@ nk_font_bake(struct nk_font_baker *baker, void *image_memory, int width, int hei
                 dst_font->ascent = ((float)unscaled_ascent * font_scale);
                 dst_font->descent = ((float)unscaled_descent * font_scale);
                 dst_font->glyph_offset = glyph_n;
+                dst_font->glyph_count = 0;
             }
 
             /* fill own baked font glyph array */

--- a/nuklear.h
+++ b/nuklear.h
@@ -12895,6 +12895,8 @@ nk_font_bake(struct nk_font_baker *baker, void *image_memory, int width, int hei
                 dst_font->ascent = ((float)unscaled_ascent * font_scale);
                 dst_font->descent = ((float)unscaled_descent * font_scale);
                 dst_font->glyph_offset = glyph_n;
+                // Need to zero this, or it will carry over from a previous
+                // bake, and cause a segfault when accessing glyphs[].
                 dst_font->glyph_count = 0;
             }
 
@@ -25466,6 +25468,9 @@ nk_tooltipfv(struct nk_context *ctx, const char *fmt, va_list args)
 ///    - [yy]: Minor version with non-breaking API and library changes
 ///    - [zz]: Bug fix version with no direct changes to API
 ///
+/// - 2019/09/08 (4.01.1) - Fixed a bug wherein re-baking of fonts caused a segmentation
+///                         fault due to dst_font->glyph_count not being zeroed on subsequent
+///                         bakes of the same set of fonts.
 /// - 2019/06/23 (4.01.0) - Added nk_***_get_scroll and nk_***_set_scroll for groups, windows, and popups
 /// - 2019/06/12 (4.00.3) - Fix panel background drawing bug
 /// - 2018/10/31 (4.00.2) - Added NK_KEYSTATE_BASED_INPUT to "fix" state based backends

--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -8,6 +8,9 @@
 ///    - [yy]: Minor version with non-breaking API and library changes
 ///    - [zz]: Bug fix version with no direct changes to API
 ///
+/// - 2019/09/08 (4.01.1) - Fixed a bug wherein re-baking of fonts caused a segmentation
+///                         fault due to dst_font->glyph_count not being zeroed on subsequent
+///                         bakes of the same set of fonts.
 /// - 2019/06/23 (4.01.0) - Added nk_***_get_scroll and nk_***_set_scroll for groups, windows, and popups
 /// - 2019/06/12 (4.00.3) - Fix panel background drawing bug
 /// - 2018/10/31 (4.00.2) - Added NK_KEYSTATE_BASED_INPUT to "fix" state based backends

--- a/src/nuklear_font.c
+++ b/src/nuklear_font.c
@@ -2347,6 +2347,8 @@ nk_font_bake(struct nk_font_baker *baker, void *image_memory, int width, int hei
                 dst_font->ascent = ((float)unscaled_ascent * font_scale);
                 dst_font->descent = ((float)unscaled_descent * font_scale);
                 dst_font->glyph_offset = glyph_n;
+                // Need to zero this, or it will carry over from a previous
+                // bake, and cause a segfault when accessing glyphs[].
                 dst_font->glyph_count = 0;
             }
 

--- a/src/nuklear_font.c
+++ b/src/nuklear_font.c
@@ -2347,6 +2347,7 @@ nk_font_bake(struct nk_font_baker *baker, void *image_memory, int width, int hei
                 dst_font->ascent = ((float)unscaled_ascent * font_scale);
                 dst_font->descent = ((float)unscaled_descent * font_scale);
                 dst_font->glyph_offset = glyph_n;
+                dst_font->glyph_count = 0;
             }
 
             /* fill own baked font glyph array */


### PR DESCRIPTION
The issue is that the loaded fonts store their offsets. The first bake we get the correct, zero offsets.

```
(gdb) p {dst_font->glyph_offset,dst_font->glyph_count,glyph_count}
$6 = {0, 0, 0}
(gdb) c
Continuing.
[Switching to thread 10 (Thread 0x7fffdae1a700 (LWP 10511))](running)

Thread 1 "renoise" hit Breakpoint 4, nk_font_bake (baker=0xa6d1ba0, image_memory=0xa6e0f10, width=512, height=2048, glyphs=0xa6d9100, glyphs_count=672, config_list=0x8949760, font_count=3) at thirdparty/nuklear/nuklear.h:11536
11536	            for (i = 0; i < tmp->range_count; ++i) {
(gdb) p {dst_font->glyph_offset,dst_font->glyph_count,glyph_count}
$7 = {224, 0, 0}
(gdb) c
Continuing.
[Switching to thread 10 (Thread 0x7fffdae1a700 (LWP 10511))](running)

Thread 1 "renoise" hit Breakpoint 4, nk_font_bake (baker=0xa6d1ba0, image_memory=0xa6e0f10, width=512, height=2048, glyphs=0xa6d9100, glyphs_count=672, config_list=0x8949760, font_count=3) at thirdparty/nuklear/nuklear.h:11536
11536	            for (i = 0; i < tmp->range_count; ++i) {
(gdb) p {dst_font->glyph_offset,dst_font->glyph_count,glyph_count}
$8 = {448, 0, 0}
```

But the second time we try to bake without adding any new fonts, the offsets have the glyph_count at non-zero.

```
11536	            for (i = 0; i < tmp->range_count; ++i) {
(gdb) p {dst_font->glyph_offset,dst_font->glyph_count,glyph_count}
$9 = {0, 224, 0}
(gdb) r
```

Which causes a segfault here:

`                    glyph = &glyphs[dst_font->glyph_offset + dst_font->glyph_count + (unsigned int)glyph_count];`


You're probably wondering why anyone would want to re-bake without adding any new fonts. My application requires me to bring up and tear down the X11 context over the course of execution. I need to be able to push the texture to the video card for rendering every time the context is brought up, but I want to optimise by not re-adding fonts that were already loaded (and decompressed).

My testing was done on version 2.00.4. I plan on upgrading my project to use master HEAD soon. If you need me to test on HEAD, I can do that, but probably in a little while.