### PR TITLE
Fix SDL2 demos main signature

### DIFF
--- a/demo/sdl_opengl2/main.c
+++ b/demo/sdl_opengl2/main.c
@@ -67,7 +67,7 @@
  *
  * ===============================================================*/
 int
-main(void)
+main(int argc, char *argv[])
 {
     /* Platform */
     SDL_Window *win;

--- a/demo/sdl_opengl3/main.c
+++ b/demo/sdl_opengl3/main.c
@@ -70,7 +70,7 @@
  *                          DEMO
  *
  * ===============================================================*/
-int main(void)
+int main(int argc, char *argv[])
 {
     /* Platform */
     SDL_Window *win;


### PR DESCRIPTION
Current SDL2 nuklear demos fail to build on Windows (mingw64) :
```
nuklear/demo/sdl_opengl3$ make
rm -f bin/demo.exe
cc main.c -std=c99 -pedantic -O2 -o bin/demo.exe -lmingw32 -lSDL2main -lSDL2 -lopengl32 -lm -lGLU32 -lGLEW32
In file included from C:/msys64/mingw64/include/SDL2/SDL.h:32,
                 from main.c:14:
main.c:73:5: error: conflicting types for 'SDL_main'
   73 | int main(void)
      |     ^~~~
In file included from C:/msys64/mingw64/include/SDL2/SDL.h:32,
                 from main.c:14:
C:/msys64/mingw64/include/SDL2/SDL_main.h:121:29: note: previous declaration of 'SDL_main' was here
  121 | extern SDLMAIN_DECLSPEC int SDL_main(int argc, char *argv[]);
      |                             ^~~~~~~~
make: *** [Makefile:25: demo.exe] Error 1
```
This trivial patch changes ```int main(void)``` into ```int main(int argc, char *argv[])``` which is the correct C main() signature